### PR TITLE
First stage of stricter typing

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,4 +1,4 @@
-import { isObject, isString } from './is';
+import { isObject, isString, isNodeValueWithParent } from './is';
 import { NodeValue, TrackingType } from './observableInterfaces';
 import { updateTracking } from './tracking';
 
@@ -35,8 +35,8 @@ export function peek(node: NodeValue) {
 
 export function getNodeValue(node: NodeValue): any {
     const arr: (string | number)[] = [];
-    let n = node;
-    while (n?.key !== undefined) {
+    let n: NodeValue = node;
+    while (isNodeValueWithParent(n)) {
         arr.push(n.key);
         n = n.parent;
     }
@@ -80,7 +80,7 @@ export function getChildNode(node: NodeValue, key: string | number): NodeValue {
 export function ensureNodeValue(node: NodeValue) {
     let value = getNodeValue(node);
     if (!value) {
-        if (node.parent) {
+        if (isNodeValueWithParent(node)) {
             const parent = ensureNodeValue(node.parent);
             value = parent[node.key] = {};
         } else {
@@ -114,4 +114,19 @@ export function shouldTreatAsOpaque(value: any) {
             return true;
         }
     }
+}
+
+export type IDKey = 'id' | '_id' | '__id';
+export type IDValue = string | number;
+
+export function findIDKey(obj: unknown | undefined): IDKey | undefined {
+    return isObject(obj)
+        ? 'id' in obj
+            ? 'id'
+            : '_id' in obj
+                ? '_id'
+                : '__id' in obj
+                    ? '__id'
+                    : undefined
+        : undefined;
 }

--- a/src/is.ts
+++ b/src/is.ts
@@ -1,3 +1,5 @@
+import type { NodeValueWithParent, NodeValueWithoutParent } from './observableInterfaces';
+
 /** @internal */
 export function isArray(obj: unknown): obj is Array<any> {
     return Array.isArray(obj);
@@ -8,16 +10,16 @@ export function isString(obj: unknown): obj is string {
 }
 /** @internal */
 export function isObject(obj: unknown): obj is Record<any, any> {
-    return obj && typeof obj === 'object' && !isArray(obj);
+    return !!obj && typeof obj === 'object' && !isArray(obj);
 }
 /** @internal */
 export function isFunction(obj: unknown): obj is Function {
     return typeof obj === 'function';
 }
 /** @internal */
-export function isPrimitive(arg) {
-    var type = typeof arg;
-    return arg !== undefined && arg !== null && type != 'object' && type != 'function';
+export function isPrimitive(arg: unknown): arg is string | number | bigint | boolean | symbol {
+    const type = typeof arg;
+    return arg !== undefined && type !== 'object' && type !== 'function';
 }
 /** @internal */
 export function isObjectEmpty(obj: object) {
@@ -29,21 +31,25 @@ export function isSymbol(obj: unknown): obj is symbol {
 }
 /** @internal */
 export function isBoolean(obj: unknown): obj is boolean {
-    return obj === true || obj === false;
+    return typeof obj === 'boolean';
 }
 /** @internal */
 export function isPromise<T>(obj: unknown): obj is Promise<T> {
-    return isFunction((obj as any)?.then) && isFunction((obj as any).catch);
+    return obj instanceof Promise;
 }
-export function isEmpty(obj: object) {
+export function isEmpty(obj: object): boolean {
     return obj && Object.keys(obj).length === 0;
 }
-const mapPrimitives = new Map([
-    ['boolean', true],
-    ['string', true],
-    ['number', true],
+const setPrimitives = new Set([
+    'boolean',
+    'string',
+    'number',
 ]);
 /** @internal */
-export function isActualPrimitive(arg) {
-    return mapPrimitives.has(typeof arg);
+export function isActualPrimitive(arg: unknown): arg is boolean | string | number {
+    return setPrimitives.has(typeof arg);
+}
+/** @internal */
+export function isNodeValueWithParent(node: NodeValueWithParent | NodeValueWithoutParent): node is NodeValueWithParent {
+    return !!node.parent;
 }

--- a/src/observableInterfaces.ts
+++ b/src/observableInterfaces.ts
@@ -236,7 +236,7 @@ export type ObservablePrimitiveChild<T = any> = [T] extends [boolean]
 export type ObservableObjectOrArray<T> = T extends any[] ? ObservableArray<T> : ObservableObject<T>;
 
 export type ObservableComputed<T = any> = ObservableBaseFns<T> & ObservableComputedFnsRecursive<T>;
-export declare type Observable<T = any> = [T] extends [object] ? ObservableObjectOrArray<T> : ObservablePrimitive<T>;
+export type Observable<T = any> = [T] extends [object] ? ObservableObjectOrArray<T> : ObservablePrimitive<T>;
 
 export type ObservableReadable<T = any> =
     | ObservableBaseFns<T>
@@ -258,6 +258,9 @@ export interface NodeValue {
     root: ObservableWrapper;
     listeners?: Set<{ track: TrackingType; noArgs?: boolean; listener: ListenerFn }>;
 }
+
+export type NodeValueWithParent = NodeValue & Required<Pick<NodeValue, 'parent' | 'key'>>;
+export type NodeValueWithoutParent = NodeValue & Omit<NodeValue, 'parent' | 'key'>;
 
 /** @internal */
 export interface TrackingNode {

--- a/src/react/useSelector.ts
+++ b/src/react/useSelector.ts
@@ -1,7 +1,7 @@
 import { computeSelector, observe, Selector, symbolUndef, isPrimitive } from '@legendapp/state';
 import { useReducer } from 'react';
 
-const Update = (s) => s + 1;
+const Update = (s: number) => s + 1;
 
 export function useSelector<T>(
     selector: Selector<T>,

--- a/tests/react.test.ts
+++ b/tests/react.test.ts
@@ -132,7 +132,7 @@ describe('useSelector', () => {
         const obs = observable('hi');
         let num = 0;
         let numSelects = 0;
-        let fr;
+        let fr: () => void;
         function Test() {
             fr = useReducer((s) => s + 1, 0)[1];
             const val = useSelector(() => {
@@ -175,10 +175,11 @@ describe('useSelector', () => {
 
 describe('For', () => {
     test('Array insert has stable reference', async () => {
+        type TestObject = { id: number; label: string; };
         const obs = observable({
-            items: [{ id: 0, label: '0' }] as Array<{ id: number; label: string }>,
+            items: [{ id: 0, label: '0' }] as TestObject[],
         });
-        function Item({ item }) {
+        function Item({ item }: { item: Observable<TestObject>; }) {
             const data = useSelector(item);
             return createElement('li', { id: data.id }, data.label);
         }
@@ -200,19 +201,17 @@ describe('For', () => {
     });
     test('Array insert has stable reference 2', () => {
         enableLegendStateReact();
+        type TestObject = { id: string; label: string; };
         const obs = observable({
             items: [
                 { id: 'B', label: 'B' },
                 { id: 'A', label: 'A' },
-            ] as Array<{ id: string; label: string }>,
+            ] as TestObject[],
         });
         function Item({
             item,
         }: {
-            item: Observable<{
-                id: number;
-                label: string;
-            }>;
+            item: Observable<TestObject>;
         }) {
             const data = useSelector(item);
             return createElement('li', { id: data.id }, data.label);
@@ -226,7 +225,7 @@ describe('For', () => {
         expect(items.length).toEqual(2);
 
         act(() => {
-            obs.items.splice(0, 0, { id: 'C', label: 'C' });
+            obs.items.splice(0, 0, { id: 'C', label: 'C' } as TestObject);
         });
 
         items = container.querySelectorAll('li');

--- a/tests/tests.test.ts
+++ b/tests/tests.test.ts
@@ -329,7 +329,14 @@ describe('Listeners', () => {
         );
     });
     test('Deep object set primitive undefined', () => {
-        const obs = observable({ test: { test2: { test3: 'hi' } } });
+        interface Data {
+            test: {
+                test2: {
+                    test3: string | undefined; // TODO: Make it work as an optional property
+                };
+            };
+        }
+        const obs = observable<Data>({ test: { test2: { test3: 'hi' } } });
         const handler = expectChangeHandler(obs);
         obs.test.test2.test3.set(undefined);
         expect(handler).toHaveBeenCalledWith(
@@ -339,7 +346,14 @@ describe('Listeners', () => {
         );
     });
     test('Deep object set undefined', () => {
-        const obs = observable({ test: { test2: { test3: 'hi' } } });
+        interface Data {
+            test: {
+                test2: {
+                    test3: string;
+                } | undefined; // TODO: Make it work as an optional property
+            };
+        }
+        const obs = observable<Data>({ test: { test2: { test3: 'hi' } } });
         const handler = expectChangeHandler(obs);
         obs.test.test2.set(undefined);
         expect(handler).toHaveBeenCalledWith({ test: { test2: undefined } }, { test: { test2: { test3: 'hi' } } }, [
@@ -347,7 +361,10 @@ describe('Listeners', () => {
         ]);
     });
     test('Start null set to something', () => {
-        const obs = observable({ test: null });
+        interface Data {
+            test: null | Record<string, string>;
+        }
+        const obs = observable<Data>({ test: null });
         const handler = expectChangeHandler(obs);
         obs.test.set({ test2: 'hi' });
         expect(handler).toHaveBeenCalledWith({ test: { test2: 'hi' } }, { test: null }, [
@@ -361,7 +378,10 @@ describe('Listeners', () => {
         ]);
     });
     test('Start undefined set to something', () => {
-        const obs = observable({ test: undefined });
+        interface Data {
+            test: undefined | Record<string, string>;
+        }
+        const obs = observable<Data>({ test: undefined });
         const handler = expectChangeHandler(obs);
         obs.test.set({ test2: 'hi' });
         expect(handler).toHaveBeenCalledWith({ test: { test2: 'hi' } }, { test: undefined }, [
@@ -369,7 +389,10 @@ describe('Listeners', () => {
         ]);
     });
     test('Set with object should only fire listeners once', () => {
-        const obs = observable({ test: undefined });
+        interface Data {
+            test: undefined | Record<string, string>;
+        }
+        const obs = observable<Data>({ test: undefined });
         const handler = expectChangeHandler(obs);
         obs.test.set({ test2: 'hi', test3: 'hi3', test4: 'hi4' });
         expect(handler).toHaveBeenCalledTimes(1);
@@ -423,7 +446,12 @@ describe('Listeners', () => {
         expect(handler).toHaveBeenCalledWith('hello', 'hi', [{ path: [], valueAtPath: 'hello', prevAtPath: 'hi' }]);
     });
     test('Set undefined deep with deep listener', () => {
-        const obs = observable({ obj: { test: 'hi' } });
+        interface Data {
+            obj: {
+                test: string | undefined;
+            }
+        }
+        const obs = observable<Data>({ obj: { test: 'hi' } });
         const handler = expectChangeHandler(obs.obj.test);
         obs.obj.test.set(undefined);
         expect(handler).toHaveBeenCalledWith(undefined, 'hi', [{ path: [], valueAtPath: undefined, prevAtPath: 'hi' }]);
@@ -539,16 +567,35 @@ describe('undefined', () => {
         expect(obs.test.get()).toEqual(undefined);
     });
     test('Can dot through undefined', () => {
-        const obs = observable({ test: undefined } as { test: { test2: { test3: string } } });
+        interface Data {
+            test?: {
+                test2?: {
+                    test3?: string;
+                }
+            };
+        }
+        const obs = observable<Data>({ test: undefined });
         expect(obs.test.test2.test3.get()).toEqual(undefined);
     });
     test('Can set through undefined', () => {
-        const obs = observable({ test: undefined } as { test: { test2: { test3: string } } });
+        interface Data {
+            test?: {
+                test2?: {
+                    test3?: string;
+                }
+            };
+        }
+        const obs = observable<Data>({ test: undefined });
         obs.test.test2.test3.set('hi');
         expect(obs.test.test2.test3.get()).toEqual('hi');
     });
     test('Set undefined to value and back', () => {
-        const obs = observable({ test: { test2: { test3: undefined } } });
+        // TODO: Replace `any`
+        type Data = any;
+        // type Data = {
+        //     [key: string]: string | Data | undefined;
+        // };
+        const obs = observable<Data>({ test: { test2: { test3: undefined } } });
         const handler = expectChangeHandler(obs.test);
         expect(obs.test.get()).toEqual({ test2: { test3: undefined } });
         expect(obs.test.test2.get()).toEqual({ test3: undefined });
@@ -756,7 +803,10 @@ describe('Primitives', () => {
 });
 describe('Array', () => {
     test('Basic array', () => {
-        const obs = observable({ arr: [] });
+        interface Data {
+            arr: number[];
+        }
+        const obs = observable<Data>({ arr: [] });
         expect(obs.arr.get()).toEqual([]);
         obs.arr.set([1, 2, 3]);
         expect(obs.arr.get()).toEqual([1, 2, 3]);
@@ -778,13 +828,15 @@ describe('Array', () => {
         ]);
     });
     test('Array at root', () => {
-        const obs = observable([]);
+        type Data = number[];
+        const obs = observable<Data>([]);
         expect(obs.get()).toEqual([]);
         obs.set([1, 2, 3]);
         expect(obs.get()).toEqual([1, 2, 3]);
     });
     test('Array at root listens', () => {
-        const obs = observable([]);
+        type Data = number[];
+        const obs = observable<Data>([]);
         expect(obs.get()).toEqual([]);
         const handler = expectChangeHandler(obs);
 
@@ -848,7 +900,10 @@ describe('Array', () => {
         expect(obs.test.get()).toEqual([1, 2, 3, 4, 5]);
     });
     test('Array set', () => {
-        const obs = observable({ test: [] });
+        interface Data {
+            test: Array<{ id: number; }>;
+        }
+        const obs = observable<Data>({ test: [] });
         const arr = [];
         for (let i = 0; i < 1000; i++) {
             arr[i] = { id: i };
@@ -891,7 +946,10 @@ describe('Array', () => {
         expect(obs.test[0].get()).toEqual({ id: 5, text: 5 });
     });
     test('Array swap if empty', () => {
-        const obs = observable({ test: [] });
+        interface Data {
+            test: Array<unknown>;
+        }
+        const obs = observable<Data>({ test: [] });
         let tmp = obs.test[1];
         obs.test[1].set(obs.test[4]);
         expect(obs.test.get()).toEqual([undefined, undefined]);
@@ -1021,8 +1079,11 @@ describe('Array', () => {
         expect(vals).toEqual([true]);
     });
     test('Array forEach returns observables', () => {
-        const obs = observable({ arr: [{ text: 'hi' }] });
-        const arr = [];
+        interface Data {
+            arr: Array<{ text: string; }>
+        }
+        const obs = observable<Data>({ arr: [{ text: 'hi' }] });
+        const arr: unknown[] = [];
         obs.arr.forEach((a) => arr.push(isObservable(a)));
         expect(arr).toEqual([true]);
     });
@@ -1038,7 +1099,10 @@ describe('Array', () => {
         expect(handler).not.toBeCalled();
     });
     test('Array has stable reference', () => {
-        const obs = observable({ arr: [] });
+        interface Data {
+            arr: Array<{ id: string, text: string; }>;
+        }
+        const obs = observable<Data>({ arr: [] });
         obs.arr.set([
             { id: 'h1', text: 'hi' },
             { id: 'h2', text: 'hello' },
@@ -1088,7 +1152,10 @@ describe('Array', () => {
         ]);
     });
     test('Array has stable references 3', () => {
-        const obs = observable({ arr: [] });
+        interface Data {
+            arr: Array<{ id: string, text: string; }>;
+        }
+        const obs = observable<Data>({ arr: [] });
         obs.arr.set([
             { id: 'h1', text: 'hi' },
             { id: 'h2', text: 'h2' },
@@ -1492,7 +1559,11 @@ describe('on functions', () => {
 });
 describe('Shallow', () => {
     test('Shallow set primitive', () => {
-        const obs = observable({ val: false } as { val: boolean; val2?: number });
+        interface Data {
+            val: boolean;
+            val2?: number;
+        }
+        const obs = observable<Data>({ val: false });
         const handler = jest.fn();
         obs.onChange(handler, true);
         obs.val.set(true);
@@ -1508,7 +1579,11 @@ describe('Shallow', () => {
         expect(handler).not.toHaveBeenCalled();
     });
     test('Shallow array', () => {
-        const obs = observable({ data: [], selected: 0 });
+        interface Data {
+            data: Array<{ text: number; }>;
+            selected: number;
+        }
+        const obs = observable<Data>({ data: [], selected: 0 });
         const handler = jest.fn();
         obs.data.onChange(handler, true);
         obs.data.set([{ text: 1 }, { text: 2 }]);
@@ -1518,7 +1593,10 @@ describe('Shallow', () => {
         expect(handler).toHaveBeenCalledTimes(1);
     });
     test('Key delete notifies shallow', () => {
-        const obs = observable({ test: { key1: { text: 'hello' }, key2: { text: 'hello2' } } });
+        interface Data {
+            test: Record<string, { text: string; } | undefined>;
+        }
+        const obs = observable<Data>({ test: { key1: { text: 'hello' }, key2: { text: 'hello2' } } });
         const handler = jest.fn();
         obs.test.onChange(handler, true);
 
@@ -1537,7 +1615,10 @@ describe('Shallow', () => {
         expect(handler).toHaveBeenCalledTimes(2);
     });
     test('Array splice notifies shallow', () => {
-        const obs = observable({ arr: [{ text: 'hello' }, { text: 'hello2' }] });
+        interface Data {
+            arr: Array<{ text: string }>;
+        }
+        const obs = observable<Data>({ arr: [{ text: 'hello' }, { text: 'hello2' }] });
         const handler = jest.fn();
         const handler2 = jest.fn();
         obs.arr.onChange(handler, true);
@@ -1554,7 +1635,12 @@ describe('Shallow', () => {
         expect(handler2).toHaveBeenCalledTimes(2);
     });
     test('Shallow tracks object getting set to undefined', () => {
-        const obs = observable({ test: { text: 'hi' } });
+        interface Data {
+            test: undefined | {
+                text: string;
+            };
+        }
+        const obs = observable<Data>({ test: { text: 'hi' } });
         const handler = jest.fn();
         obs.test.onChange(handler, true);
 
@@ -1727,18 +1813,20 @@ describe('Batching', () => {
 });
 describe('Observable with promise', () => {
     test('Promise', async () => {
-        let resolver;
+        let resolver: ((value: number) => void) | undefined;
         const promise = new Promise<number>((resolve) => {
             resolver = resolve;
         });
         const obs = observable(promise);
         expect(obs.get()).toEqual(undefined);
-        resolver(10);
+        if (resolver) {
+            resolver(10);
+        }
         await promiseTimeout(0);
         expect(obs.get()).toEqual(10);
     });
     test('when with promise observable', async () => {
-        let resolver;
+        let resolver: ((value: number) => void) | undefined;
         const promise = new Promise<number>((resolve) => {
             resolver = resolve;
         });
@@ -1749,7 +1837,9 @@ describe('Observable with promise', () => {
         const fn = jest.fn();
         when(() => obs.get() === 10, fn);
 
-        resolver(10);
+        if (resolver) {
+            resolver(10);
+        }
 
         await promiseTimeout(1000);
 
@@ -1814,7 +1904,7 @@ describe('Primitive root', () => {
     });
     test('observable root can be primitive', () => {
         const obs = observable(1);
-        const node = obs[symbolGetNode];
+        const node = (obs as any)[symbolGetNode];
         expect(node.root._).toEqual(1);
     });
 });


### PR DESCRIPTION
For this PR I have upgraded to the latest version and reapplied some of my previous "experiments", which I think should quite straight forward and safe to merge, but please have a look. I have left out changes that were too experimental or incomplete.

One thing that I added today is a differentiation of `NodeValue` to `NodeValueWithParent` and `NodeValueWithoutParent` (in `src/observableInterfaces.ts`). From your code I inferred that the properties `parent` and `key` are either defined or not defined, depending whether the `NodeValue` has a parent or not. By separating the types I think it becomes a bit easier to deal with those objects when it can be safely assumed that if one of those properties exists, the other one does too.

If you think this is too much for one PR, please let me know and I'll try to break it down a bit more.