### PR TITLE
Cleaner separation of NodeValue as union type

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,4 +1,4 @@
-import { isObject, isString, isNodeValueWithParent } from './is';
+import { isObject, isString, isChildNodeValue } from './is';
 import { NodeValue, TrackingType } from './observableInterfaces';
 import { updateTracking } from './tracking';
 
@@ -37,7 +37,7 @@ export function peek(node: NodeValue) {
 export function getNodeValue(node: NodeValue): any {
     const arr: (string | number)[] = [];
     let n: NodeValue = node;
-    while (isNodeValueWithParent(n)) {
+    while (isChildNodeValue(n)) {
         arr.push(n.key);
         n = n.parent;
     }
@@ -81,7 +81,7 @@ export function getChildNode(node: NodeValue, key: string | number): NodeValue {
 export function ensureNodeValue(node: NodeValue) {
     let value = getNodeValue(node);
     if (!value) {
-        if (isNodeValueWithParent(node)) {
+        if (isChildNodeValue(node)) {
             const parent = ensureNodeValue(node.parent);
             value = parent[node.key] = {};
         } else {

--- a/src/is.ts
+++ b/src/is.ts
@@ -1,4 +1,4 @@
-import type { NodeValueWithParent, NodeValueWithoutParent } from './observableInterfaces';
+import type { NodeValue, RootNodeValue, ChildNodeValue } from './observableInterfaces';
 
 /** @internal */
 export function isArray(obj: unknown): obj is Array<any> {
@@ -50,6 +50,6 @@ export function isActualPrimitive(arg: unknown): arg is boolean | string | numbe
     return setPrimitives.has(typeof arg);
 }
 /** @internal */
-export function isNodeValueWithParent(node: NodeValueWithParent | NodeValueWithoutParent): node is NodeValueWithParent {
+export function isChildNodeValue(node: NodeValue): node is ChildNodeValue {
     return !!node.parent;
 }

--- a/src/observableInterfaces.ts
+++ b/src/observableInterfaces.ts
@@ -254,19 +254,32 @@ export type ObservableWriteable<T = any> =
     | ObservablePrimitiveChildFns<T>
     | ObservableObjectFns<T>;
 
-export interface NodeValue {
-    id: number;
-    parent?: NodeValue;
-    children?: Map<string | number, NodeValue>;
-    proxy?: object;
-    key?: string | number;
-    isActivatedPrimitive?: boolean;
-    root: ObservableWrapper;
-    listeners?: Set<{ track: TrackingType; noArgs?: boolean; listener: ListenerFn }>;
+interface NodeValueListener {
+    track: TrackingType;
+    noArgs?: boolean;
+    listener: ListenerFn;
 }
 
-export type NodeValueWithParent = NodeValue & Required<Pick<NodeValue, 'parent' | 'key'>>;
-export type NodeValueWithoutParent = NodeValue & Omit<NodeValue, 'parent' | 'key'>;
+interface BaseNodeValue {
+    id: number;
+    children?: Map<string | number, ChildNodeValue>;
+    proxy?: object;
+    isActivatedPrimitive?: boolean;
+    root: ObservableWrapper;
+    listeners?: Set<NodeValueListener>;
+}
+
+export interface RootNodeValue extends BaseNodeValue {
+    parent?: undefined;
+    key?: undefined;
+}
+
+export interface ChildNodeValue extends BaseNodeValue {
+    parent: NodeValue;
+    key: string | number;
+}
+
+export type NodeValue = RootNodeValue | ChildNodeValue;
 
 /** @internal */
 export interface TrackingNode {


### PR DESCRIPTION
I have slightly changed the typing and naming of `NodeValue` from my previous PR. Instead of `NodeValueWithParent` and `NodeValueWithoutParent` it's now `RootNodeValue` and `ChildNodeValue`, while `NodeValue` is a union type. I think this is a bit cleaner. The union type makes it easier to enforce the properties `parent` and `key` to be either both defined or both undefined.