### PR TITLE
Small TS strict improvements in trackHistory and batching

### DIFF
--- a/src/batching.ts
+++ b/src/batching.ts
@@ -12,7 +12,7 @@ interface BatchItem {
     }[];
     node?: NodeValue;
 }
-let timeout;
+let timeout: ReturnType<typeof setTimeout> | undefined;
 let numInBatch = 0;
 let _batch: (BatchItem | (() => void))[] = [];
 // Use a Map of callbacks for fast lookups to update the BatchItem

--- a/src/history/trackHistory.ts
+++ b/src/history/trackHistory.ts
@@ -23,17 +23,20 @@ function constructObject(path: (string | number)[], value: any): object {
     return out;
 }
 
+// This type is purely for documentation.
+type TimestampAsString = string;
+
 export function trackHistory<T>(
     obs: ObservableReadable<T>,
-    targetObservable?: ObservableWriteable<Record<number, Partial<T>>>
+    targetObservable?: ObservableWriteable<Record<TimestampAsString, Partial<T>>>
 ) {
-    const history = targetObservable ?? observable<Record<number, Partial<T>>>();
+    const history = targetObservable ?? observable<Record<TimestampAsString, Partial<T>>>();
 
     obs.onChange((_, __, changes) => {
         // Don't save history if this is a remote change.
         // History will be saved remotely by the client making the local change.
         if (!tracking.inRemoteChange) {
-            const time = Date.now();
+            const time: TimestampAsString = Date.now().toString();
 
             // Save to history observable by date, with the previous value
             for (let i = 0; i < changes.length; i++) {

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -14,8 +14,10 @@ describe('History', () => {
         obs.set({ test: 'hello' });
 
         const historyKeys = Object.keys(history);
-
-        expect(history.get()[historyKeys[0]]).toEqual({ test: 'hi' });
+        const firstKey = historyKeys[0]; // '1667050028427' (string)
+        const historyObj = history.get(); // { '1667050028427': { test: 'hi' } }
+        const firstEntry = historyObj[firstKey]; // { test: 'hi' }
+        expect(firstEntry).toEqual({ test: 'hi' });
     });
     test('Two in history', async () => {
         const obs = observable({ test: 'hi' });


### PR DESCRIPTION
In `trackHistory` an object type was defined as `Record<number, Partial<T>>`. The keys are timestamps.

However, a test failed (in strict mode) due to a typing error when the key was expected to be a number, but `Object.keys()` actually returns strings. Object keys are implicitly cast to stings even when set as numbers, so the keys will always be strings.

Unrelated but tiny change: I also added a type for `let timeout`.