### PR TITLE
Fix missing imports in the examples in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See [the documentation](https://www.legendapp.com/open-source/state) for more de
 
 ```jsx
 import { observable } from "@legendapp/state"
+import { observer } from "@legendapp/state/react";
 
 // Create an observable object
 const state = observable({ settings: { theme: 'dark' } })
@@ -85,7 +86,7 @@ const Component = observer(function Component() {
             </Button>
         </div>
     )
-}
+})
 ```
 
 ## Highlights


### PR DESCRIPTION
When I looked at the readme file, I wanted to use the sample code, but I couldn't find where the observer was imported from, and the TS type prompt didn't help me, so I looked for a long time and finally found it at the end of the official documentation I still couldn't find the location to export the persistObservable