### PR TITLE
feat: add fromSpecObservable helper

### DIFF
--- a/src/helpers/from-spec-observable.ts
+++ b/src/helpers/from-spec-observable.ts
@@ -1,0 +1,39 @@
+import { observable } from '@legendapp/state';
+
+interface SpecObserver<T = unknown, E = unknown> {
+    next: (value: T) => void;
+    error: (error: E) => void;
+    complete: () => void;
+}
+
+interface SpecSubscription {
+    unsubscribe(): void;
+    closed?: boolean;
+}
+
+interface SpecObservable<T> {
+    subscribe: (observer: SpecObserver<T, any>) => SpecSubscription;
+}
+
+export function fromSpecObservable<T = unknown>(specObservable: SpecObservable<T>, initialValue?: T) {
+    const obs = observable<T>(initialValue);
+    const { unsubscribe } = specObservable.subscribe({
+        next: (value) => {
+            // I don't think this is the correct way to do this...
+            // I think this might need to be a call to `mergeIntoObservable`,
+            // but I will ask Mr. Meistrich
+            obs.set((_: T) => value);
+        },
+        error: (error) => {
+            // I'm not sure what to do with the error...
+            // Maybe set it as the current value?
+        },
+        complete: () => {
+            // Not sure what to do here either...
+            // Maybe just call unsubscribe
+            unsubscribe();
+        },
+    });
+
+    return obs;
+}


### PR DESCRIPTION
Hey there! I have a use case that requires me to convert a [spec-compliant observable](https://github.com/tc39/proposal-observable) to a legend-state observable. Could we include a simple helper to the legend-state package to facilitate this? I think this will be a common pattern (subscribing observables to other types of streams), so I think it's worth including as a helper. I'm also open to changing the api so it doesn't conform so strictly to the spec-compliant observable; I just think that it offers the most standardized solution and the most flexibility.

This PR includes a naive implementation that I'd like to get some guidance on. Feel free to comment on the best way to change the code.

What do you think?