### PR TITLE
Update 2-react-API.mdx

### DIFF
--- a/docs/3-react/2-react-API.mdx
+++ b/docs/3-react/2-react-API.mdx
@@ -81,7 +81,7 @@ function ProfilePage() {
 
     // Observe a single observable with a callback when it changes
     useObserve(profile.name, ({ value }) => {
-        document.title = `${e.value} - Profile`
+        document.title = `${value} - Profile`
     })
 
     // Observe an event with a callback when it changes


### PR DESCRIPTION
Hello,

Why we should use `e.value`? meanwhile it hasn't been defined yet. Looking from the params, should it be a `value`? I might be wrong and love to learn more.

Thank you.