### PR TITLE
very small changes to the docs

### DIFF
--- a/docs/1-introduction/1-introduction.mdx
+++ b/docs/1-introduction/1-introduction.mdx
@@ -37,7 +37,7 @@ See [Fast 🔥](./fast) for more details of why Legend-State is so fast.
 
 ### 3. 🔥 Fine-grained reactivity for minimal renders
 
-Legend-State lets you make your renders super fine-grained allowing only the leaves of your component tree to re-render when required, thus making your apps go faster 🔥, and removing unnecesary overhead from React's render cycle.
+Legend-State lets you make your renders super fine-grained allowing only the leaves of your component tree to re-render when required, thus making your apps go faster 🔥, and removing unnecessary overhead from React's render cycle.
 
 <Example name="Primitive">
 ```jsx
@@ -74,9 +74,9 @@ function FineGrained() {
 
 ### 4. 💾 Powerful persistence
 
-Legend-State includes a powerful [persistence plugin system](../4-guides/persistence) for local caching and remote sync. It easily enables offline-first apps by tracking changes made while offline that save when coming online, managing conflict resolution, and syncing only small diffs. We use Legend-State as the sync systems in [Legend](https://legendapp.com) and [Bravely](https://bravely.io), so it is by necessity very full featured while being simple to set up.
+Legend-State includes a powerful [persistence plugin system](../persistence) for local caching and remote sync. It easily enables offline-first apps by tracking changes made while offline that save when coming online, managing conflict resolution, and syncing only small diffs. We use Legend-State as the sync systems in [Legend](https://legendapp.com) and [Bravely](https://bravely.io), so it is by necessity very full featured while being simple to set up.
 
-Local persistence plugins for the browser and React Native are included, and a remote sync plugin for Firebase (comming soon).
+Local persistence plugins for the browser and React Native are included, and a remote sync plugin for Firebase (coming soon).
 
 ```js
 import { ObservablePersistLocalStorage } from '@legendapp/state/persist-plugins/local-storage'

--- a/docs/1-introduction/1-introduction.mdx
+++ b/docs/1-introduction/1-introduction.mdx
@@ -1,4 +1,4 @@
-Legend-State is a super fast and powerful state library for JavaScript apps with four primary goals:
+Legend-State is a super fast and powerful state library for modern JavaScript apps with four primary goals:
 
 ### 1. <span className="text-lg">🦄</span> As easy as possible to use
 
@@ -37,7 +37,7 @@ See [Fast 🔥](./fast) for more details of why Legend-State is so fast.
 
 ### 3. 🔥 Fine-grained reactivity for minimal renders
 
-Legend-State lets you make your renders super fine-grained, so your apps will be much faster because React has to do less work. The best way to be fast is to render less, less often.
+Legend-State lets you make your renders super fine-grained allowing only the leaves of your component tree to re-render when required, thus making your apps go faster 🔥, and removing unnecesary overhead from React's render cycle.
 
 <Example name="Primitive">
 ```jsx
@@ -74,9 +74,9 @@ function FineGrained() {
 
 ### 4. 💾 Powerful persistence
 
-Legend-State includes a powerful persistence plugin system for local caching and remote sync. It easily enables offline-first apps by tracking changes made while offline that save when coming online, managing conflict resolution, and syncing only small diffs. We use Legend-State as the sync systems in [Legend](https://legendapp.com) and [Bravely](https://bravely.io), so it is by necessity very full featured while being simple to set up.
+Legend-State includes a powerful [persistence plugin system](../4-guides/persistence) for local caching and remote sync. It easily enables offline-first apps by tracking changes made while offline that save when coming online, managing conflict resolution, and syncing only small diffs. We use Legend-State as the sync systems in [Legend](https://legendapp.com) and [Bravely](https://bravely.io), so it is by necessity very full featured while being simple to set up.
 
-Local persistence plugins for the browser and React Native are included, and a remote sync plugin for Firebase will be ready soon.
+Local persistence plugins for the browser and React Native are included, and a remote sync plugin for Firebase (comming soon).
 
 ```js
 import { ObservablePersistLocalStorage } from '@legendapp/state/persist-plugins/local-storage'
@@ -172,3 +172,7 @@ Continue on to [Getting Started](./getting-started) to get started!
 ## Community
 
 Join us on [Slack](https://join.slack.com/t/legendappcommunity/shared_invite/zt-1mfjknpna-vUL2s1qOuNeZL12~t2RruQ) to get involved with the Legend community.
+
+## Contributing
+
+We welcome contributions! Please read our [Contributing Guide](https://github.com/LegendApp/legend-state) on Github

--- a/docs/3-react/3-fine-grained-reactivity.mdx
+++ b/docs/3-react/3-fine-grained-reactivity.mdx
@@ -226,14 +226,18 @@ Props:
 </Show>
 ```
 
+<br />
+
 ```jsx
 import { Show } from '@legendapp/state/react'
 import { computed } from '@legendapp/state'
-function ShowExampleWithComputed() {
+import { AnimatePresence } from 'framer-motion'
+
+function ShowExampleWithSelector() {
     const state = useObservable({ collection: [] })
     return (
         <Show
-            if={computed(() => state.collection.get().length > 0)}
+            if={() => state.collection.get().length > 0}
             else={() => <div>Nothing to see here</div>}
             wrap={AnimatePresence}
         >

--- a/docs/3-react/3-fine-grained-reactivity.mdx
+++ b/docs/3-react/3-fine-grained-reactivity.mdx
@@ -146,7 +146,7 @@ const [value, setValue] = useState(1)
 
 }
 
-````
+```
 </Example>
 
 ### Memo
@@ -165,7 +165,7 @@ function Component() {
         </Computed>
     )
 }
-````
+```
 
 This is the same as the Computed example, except that the memoized children are not updated with the parent's value.
 
@@ -200,7 +200,7 @@ const [value, setValue] = useState(1)
 
 }
 
-````
+```
 </Example>
 
 ### Show
@@ -224,7 +224,7 @@ Props:
 >
     {() => <Modal />}
 </Show>
-````
+```
 
 ```jsx
 import { Show } from '@legendapp/state/react';
@@ -269,7 +269,7 @@ const state = useObservable({ show: false })
 
 }
 
-````
+```
 </Example>
 
 ### Switch
@@ -288,7 +288,7 @@ Props:
         default: () => <div>Error</div>
     }}
 </Switch>
-````
+```
 
 <Example name="Switch">
 ```jsx
@@ -318,7 +318,7 @@ const tabIndex = useObservable(0)
 
 }
 
-````
+```
 </Example>
 
 ### For
@@ -358,7 +358,7 @@ function List() {
         </div>
     )
 }
-````
+```
 
 ## Optionally add the Babel plugin
 

--- a/docs/3-react/3-fine-grained-reactivity.mdx
+++ b/docs/3-react/3-fine-grained-reactivity.mdx
@@ -336,7 +336,7 @@ Props:
 - `item`: A render function which receives the item id, and item observable or undefined
 - `itemProps`: Extra props to pass down to each item
 - `sortValues`: If the `each` parameter is an object or Map, this is a sort function for how to sort the elements. `(A: T, B: T, AKey: string, BKey: string) => number`
-- `children`: A rende function or, you can pass a render function as children instead of in the `item` prop if you prefer.
+- `children`: A render function or, you can pass a render function as children instead of in the `item` prop if you prefer.
 
 ```jsx
 import { observable } from "@legendapp/state"
@@ -380,7 +380,7 @@ To install it, add `@legendapp/state/babel` to the plugins in your `babel.config
 
 ```js
 module.exports = {
-    plugins: [...'@legendapp/state/babel'],
+    plugins: ['@legendapp/state/babel'],
 }
 ```
 
@@ -409,7 +409,11 @@ const Component = reactive(function Component({ message }) {
 })
 
 function App() {
-    return <Component $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')} />
+    return (
+        <Component
+            $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')}
+        />
+    )
 }
 ```
 
@@ -459,7 +463,11 @@ const Component = reactiveObserver(function Component({ message }) {
 })
 
 function App() {
-    return <Component $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')} />
+    return (
+        <Component
+            $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')}
+        />
+    )
 }
 ```
 

--- a/docs/3-react/3-fine-grained-reactivity.mdx
+++ b/docs/3-react/3-fine-grained-reactivity.mdx
@@ -6,12 +6,12 @@ Some teams may prefer to use Legend-State in a way that's more canonically React
 
 ## Render an observable/selector directly
 
-Use the `Memo` component to create a mini element that re-renders itself when it changes, without needing the parent component to re-render.
+Use the `Memo` component to create a mini element that re-renders itself when it changes, without needing the parent component to re-render. This is the most basic and recomended way for using Legend-State with React. The children inside of `Memo` re-render themselves when the value changes, but the parent component does not re-render.
 
 ```jsx
-import { Memo } from "@legendapp/state/react"
+import { Memo } from '@legendapp/state/react';
 
-const count$ = observable(0)
+const count$ = observable(0);
 
 // These components never re-render.
 // The Memo element re-renders itself when its value changes.
@@ -21,14 +21,14 @@ function WithObservable() {
             Count:
             <Memo>{count$}</Memo>
         </div>
-    )
+    );
 }
 function WithSelector() {
     return (
         <div>
             <Memo>{() => `Count: ${count$.get()}`}</Memo>
         </div>
-    )
+    );
 }
 ```
 
@@ -42,12 +42,12 @@ To use these components first enable the version for your platform:
 
 ```js
 // React
-import { enableReactComponents } from "@legendapp/state/config/enableReactComponents"
-enableReactComponents()
+import { enableReactComponents } from '@legendapp/state/config/enableReactComponents';
+enableReactComponents();
 
 // React Native
-import { enableReactNativeComponents } from "@legendapp/state/config/enableReactNativeComponents"
-enableReactNativeComponents()
+import { enableReactNativeComponents } from '@legendapp/state/config/enableReactNativeComponents';
+enableReactNativeComponents();
 ```
 
 That will populate `Reactive` with reactive versions of the built-in components. This example shows some examples using web components.
@@ -101,11 +101,15 @@ The child needs to be a function to be able to extract it into a separate tracki
 function Component() {
     return (
         <Computed>
-            {() => state$.messages.map(message => (
-                <div key={message.id}>{message.text} {localVar}</div>
-            ))}
+            {() =>
+                state$.messages.map((message) => (
+                    <div key={message.id}>
+                        {message.text} {localVar}
+                    </div>
+                ))
+            }
         </Computed>
-    )
+    );
 }
 ```
 
@@ -117,9 +121,9 @@ import { useRef, useState } from "react"
 import { Computed, useObservable } from "@legendapp/state/react"
 
 function ComputedExample() {
-    const renderCount = ++useRef(0).current
-    const state = useObservable({ count: 0 })
-    const [value, setValue] = useState(1)
+const renderCount = ++useRef(0).current
+const state = useObservable({ count: 0 })
+const [value, setValue] = useState(1)
 
     const onClick = () => setValue(v => v + 1)
     useInterval(() => {
@@ -139,8 +143,10 @@ function ComputedExample() {
             </Computed>
         </div>
     )
+
 }
-```
+
+````
 </Example>
 
 ### Memo
@@ -159,7 +165,7 @@ function Component() {
         </Computed>
     )
 }
-```
+````
 
 This is the same as the Computed example, except that the memoized children are not updated with the parent's value.
 
@@ -169,9 +175,9 @@ import { useRef, useState } from "react"
 import { Memo, useObservable } from "@legendapp/state/react"
 
 function MemoExample() {
-    const renderCount = ++useRef(0).current
-    const state = useObservable({ count: 0 })
-    const [value, setValue] = useState(1)
+const renderCount = ++useRef(0).current
+const state = useObservable({ count: 0 })
+const [value, setValue] = useState(1)
 
     const onClick = () => setValue(v => v + 1)
     useInterval(() => {
@@ -191,8 +197,10 @@ function MemoExample() {
             </Memo>
         </div>
     )
+
 }
-```
+
+````
 </Example>
 
 ### Show
@@ -216,6 +224,23 @@ Props:
 >
     {() => <Modal />}
 </Show>
+````
+
+```jsx
+import { Show } from '@legendapp/state/react';
+import { computed } from '@legendapp/state';
+function ShowExampleWithComputed() {
+    const state = useObservable({ collection: [] });
+    return (
+        <Show
+            if={computed(() => state.collection.get().length > 0)}
+            else={() => <div>Nothing to see here</div>}
+            wrap={AnimatePresence}
+        >
+            {() => <Modal />}
+        </Show>
+    );
+}
 ```
 
 <Example name="Show">
@@ -223,8 +248,8 @@ Props:
 import { Show } from "@legendapp/state/react"
 
 function ShowExample() {
-    const renderCount = ++useRef(0).current
-    const state = useObservable({ show: false })
+const renderCount = ++useRef(0).current
+const state = useObservable({ show: false })
 
     const onClick = () => state.show.set(show => !show)
 
@@ -241,8 +266,10 @@ function ShowExample() {
             </Show>
         </div>
     )
-})
-```
+
+}
+
+````
 </Example>
 
 ### Switch
@@ -254,22 +281,22 @@ Props:
 - `children`: An object with the possible cases of `value` as keys. If `value` doesn't match any of the cases it will use the `default` case if available.
 
 ```jsx
-<Switch value={state.index)}>
+<Switch value={state.index}>
     {{
         0: () => <div>Tab 1</div>,
         1: () => <div>Tab 2</div>,
         default: () => <div>Error</div>
     }}
 </Switch>
-```
+````
 
 <Example name="Switch">
 ```jsx
 import { Switch } from "@legendapp/state/react"
 
 function SwitchExample() {
-    const renderCount = ++useRef(0).current
-    const tabIndex = useObservable(0)
+const renderCount = ++useRef(0).current
+const tabIndex = useObservable(0)
 
     const onClick = () => tabIndex.set(v => v > 2 ? 0 : v + 1)
 
@@ -288,8 +315,10 @@ function SwitchExample() {
             </Switch>
         </div>
     )
-})
-```
+
+}
+
+````
 </Example>
 
 ### For
@@ -300,10 +329,10 @@ An `optimized` prop adds additional optimizations, but in an unusual way by re-u
 
 Props:
 - `each`: An observable (array, object, or Map)
-- `item`: A render function which receives the item id and item observable
+- `item`: A render function which receives the item id, and item observable or undefined
 - `itemProps`: Extra props to pass down to each item
 - `sortValues`: If the `each` parameter is an object or Map, this is a sort function for how to sort the elements. `(A: T, B: T, AKey: string, BKey: string) => number`
-- `children`: You can pass a render function as children instead of in the `item` prop if you prefer.
+- `children`: A rende function or, you can pass a render function as children instead of in the `item` prop if you prefer.
 
 ```jsx
 import { observable } from "@legendapp/state"
@@ -329,7 +358,7 @@ function List() {
         </div>
     )
 }
-```
+````
 
 ## Optionally add the Babel plugin
 
@@ -347,11 +376,8 @@ To install it, add `@legendapp/state/babel` to the plugins in your `babel.config
 
 ```js
 module.exports = {
-    plugins: [
-        ...
-        "@legendapp/state/babel",
-    ],
-}
+    plugins: [...'@legendapp/state/babel'],
+};
 ```
 
 If you're using typescript you can add a `.d.ts` file to your project with this in it, to expand the types to allow direct JSX children to Computed and Memo.
@@ -359,7 +385,6 @@ If you're using typescript you can add a `.d.ts` file to your project with this 
 ```js
 /// <reference types="@legendapp/state/types/babel" />
 ```
-
 
 ## Create your own reactive components
 
@@ -370,47 +395,41 @@ You can wrap external components in `reactive` to create reactive versions of al
 In this example, `reactive` adds a `$message` prop which takes a [Selector](../getting-started#Selectors), while the target component receives a normal `message` prop and is only re-rendered when `message` changes.
 
 ```js
-import { observable } from "@legendapp/state"
-import { reactive } from "@legendapp/state/react"
+import { observable } from '@legendapp/state';
+import { reactive } from '@legendapp/state/react';
 
-const isSignedIn$ = observable(false)
+const isSignedIn$ = observable(false);
 
 const Component = reactive(function Component({ message }) {
-    return (
-        <div>{message}</div>
-    )
-})
+    return <div>{message}</div>;
+});
 
 function App() {
-    return (
-        <Component
-            $message={() => isSignedIn$.get() ? 'Hello' : 'Goodbye'}
-        />
-    )
+    return <Component $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')} />;
 }
 ```
 
 In addition to wrapping your own functions, you can wrap external library components to make them reactive. In this example we make a [Framer Motion](https://www.framer.com/motion/) component reactive so that we can update its animations based on observables without needing to re-render the parent component or its children.
 
 ```js
-import { reactive } from "@legendapp/state/react"
-import { motion } from "framer-motion"
+import { reactive } from '@legendapp/state/react';
+import { motion } from 'framer-motion';
 
 const ReactiveMotionDiv = reactive(motion.div);
 
 function Component() {
     // This component renders only once
-    const width$ = useObservable(100)
+    const width$ = useObservable(100);
 
     return (
         <ReactiveMotionDiv
             $animate={() => ({
-                x: width$.get()
+                x: width$.get(),
             })}
         >
             ...
         </ReactiveMotionDiv>
-    )
+    );
 }
 ```
 
@@ -419,26 +438,24 @@ function Component() {
 This is a single HOC with the functionality of both `observer` and `reactive`. They both run the same function under the hood, with slightly different options, so this is the optimal way to have one HOC that does both at once.
 
 ```js
-import { observable } from "@legendapp/state"
-import { reactiveObserver } from "@legendapp/state/react"
+import { observable } from '@legendapp/state';
+import { reactiveObserver } from '@legendapp/state/react';
 
-const name$ = observable('Annyong')
-const isSignedIn$ = observable(false)
+const name$ = observable('Annyong');
+const isSignedIn$ = observable(false);
 
 const Component = reactiveObserver(function Component({ message }) {
-    const name = name$.get()
+    const name = name$.get();
 
     return (
-        <div>{message} {name}</div>
-    )
-})
+        <div>
+            {message} {name}
+        </div>
+    );
+});
 
 function App() {
-    return (
-        <Component
-            $message={() => isSignedIn$.get() ? 'Hello' : 'Goodbye'}
-        />
-    )
+    return <Component $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')} />;
 }
 ```
 
@@ -447,23 +464,23 @@ function App() {
 `reactiveComponents` makes multiple reactive components at once. You can use this to create your own internal library of reactive components, or to wrap UI libraries that have multiple components in a namespace like `Modal.Header` and `Modal.Footer`.
 
 ```js
-import { reactiveComponents } from "@legendapp/state/react"
-import { motion } from "framer-motion"
+import { reactiveComponents } from '@legendapp/state/react';
+import { motion } from 'framer-motion';
 
 const ReactiveMotion = reactiveComponents(motion);
 
 function Component() {
     // This component renders only once
-    const width$ = useObservable(100)
+    const width$ = useObservable(100);
 
     return (
         <ReactiveMotion.div
             $animate={() => ({
-                x: width$.get()
+                x: width$.get(),
             })}
         >
             ...
         </ReactiveMotion.div>
-    )
+    );
 }
 ```

--- a/docs/3-react/3-fine-grained-reactivity.mdx
+++ b/docs/3-react/3-fine-grained-reactivity.mdx
@@ -229,8 +229,7 @@ Props:
 <br />
 
 ```jsx
-import { Show } from '@legendapp/state/react'
-import { computed } from '@legendapp/state'
+import { Show, useObservable } from '@legendapp/state/react'
 import { AnimatePresence } from 'framer-motion'
 
 function ShowExampleWithSelector() {

--- a/docs/3-react/3-fine-grained-reactivity.mdx
+++ b/docs/3-react/3-fine-grained-reactivity.mdx
@@ -9,9 +9,9 @@ Some teams may prefer to use Legend-State in a way that's more canonically React
 Use the `Memo` component to create a mini element that re-renders itself when it changes, without needing the parent component to re-render. This is the most basic and recomended way for using Legend-State with React. The children inside of `Memo` re-render themselves when the value changes, but the parent component does not re-render.
 
 ```jsx
-import { Memo } from '@legendapp/state/react';
+import { Memo } from '@legendapp/state/react'
 
-const count$ = observable(0);
+const count$ = observable(0)
 
 // These components never re-render.
 // The Memo element re-renders itself when its value changes.
@@ -21,14 +21,14 @@ function WithObservable() {
             Count:
             <Memo>{count$}</Memo>
         </div>
-    );
+    )
 }
 function WithSelector() {
     return (
         <div>
             <Memo>{() => `Count: ${count$.get()}`}</Memo>
         </div>
-    );
+    )
 }
 ```
 
@@ -42,12 +42,12 @@ To use these components first enable the version for your platform:
 
 ```js
 // React
-import { enableReactComponents } from '@legendapp/state/config/enableReactComponents';
-enableReactComponents();
+import { enableReactComponents } from '@legendapp/state/config/enableReactComponents'
+enableReactComponents()
 
 // React Native
-import { enableReactNativeComponents } from '@legendapp/state/config/enableReactNativeComponents';
-enableReactNativeComponents();
+import { enableReactNativeComponents } from '@legendapp/state/config/enableReactNativeComponents'
+enableReactNativeComponents()
 ```
 
 That will populate `Reactive` with reactive versions of the built-in components. This example shows some examples using web components.
@@ -109,7 +109,7 @@ function Component() {
                 ))
             }
         </Computed>
-    );
+    )
 }
 ```
 
@@ -121,9 +121,9 @@ import { useRef, useState } from "react"
 import { Computed, useObservable } from "@legendapp/state/react"
 
 function ComputedExample() {
-const renderCount = ++useRef(0).current
-const state = useObservable({ count: 0 })
-const [value, setValue] = useState(1)
+    const renderCount = ++useRef(0).current
+    const state = useObservable({ count: 0 })
+    const [value, setValue] = useState(1)
 
     const onClick = () => setValue(v => v + 1)
     useInterval(() => {
@@ -227,10 +227,10 @@ Props:
 ```
 
 ```jsx
-import { Show } from '@legendapp/state/react';
-import { computed } from '@legendapp/state';
+import { Show } from '@legendapp/state/react'
+import { computed } from '@legendapp/state'
 function ShowExampleWithComputed() {
-    const state = useObservable({ collection: [] });
+    const state = useObservable({ collection: [] })
     return (
         <Show
             if={computed(() => state.collection.get().length > 0)}
@@ -239,7 +239,7 @@ function ShowExampleWithComputed() {
         >
             {() => <Modal />}
         </Show>
-    );
+    )
 }
 ```
 
@@ -248,8 +248,8 @@ function ShowExampleWithComputed() {
 import { Show } from "@legendapp/state/react"
 
 function ShowExample() {
-const renderCount = ++useRef(0).current
-const state = useObservable({ show: false })
+    const renderCount = ++useRef(0).current
+    const state = useObservable({ show: false })
 
     const onClick = () => state.show.set(show => !show)
 
@@ -295,8 +295,8 @@ Props:
 import { Switch } from "@legendapp/state/react"
 
 function SwitchExample() {
-const renderCount = ++useRef(0).current
-const tabIndex = useObservable(0)
+    const renderCount = ++useRef(0).current
+    const tabIndex = useObservable(0)
 
     const onClick = () => tabIndex.set(v => v > 2 ? 0 : v + 1)
 
@@ -377,7 +377,7 @@ To install it, add `@legendapp/state/babel` to the plugins in your `babel.config
 ```js
 module.exports = {
     plugins: [...'@legendapp/state/babel'],
-};
+}
 ```
 
 If you're using typescript you can add a `.d.ts` file to your project with this in it, to expand the types to allow direct JSX children to Computed and Memo.
@@ -395,31 +395,31 @@ You can wrap external components in `reactive` to create reactive versions of al
 In this example, `reactive` adds a `$message` prop which takes a [Selector](../getting-started#Selectors), while the target component receives a normal `message` prop and is only re-rendered when `message` changes.
 
 ```js
-import { observable } from '@legendapp/state';
-import { reactive } from '@legendapp/state/react';
+import { observable } from '@legendapp/state'
+import { reactive } from '@legendapp/state/react'
 
-const isSignedIn$ = observable(false);
+const isSignedIn$ = observable(false)
 
 const Component = reactive(function Component({ message }) {
-    return <div>{message}</div>;
-});
+    return <div>{message}</div>
+})
 
 function App() {
-    return <Component $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')} />;
+    return <Component $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')} />
 }
 ```
 
 In addition to wrapping your own functions, you can wrap external library components to make them reactive. In this example we make a [Framer Motion](https://www.framer.com/motion/) component reactive so that we can update its animations based on observables without needing to re-render the parent component or its children.
 
 ```js
-import { reactive } from '@legendapp/state/react';
-import { motion } from 'framer-motion';
+import { reactive } from '@legendapp/state/react'
+import { motion } from 'framer-motion'
 
-const ReactiveMotionDiv = reactive(motion.div);
+const ReactiveMotionDiv = reactive(motion.div)
 
 function Component() {
     // This component renders only once
-    const width$ = useObservable(100);
+    const width$ = useObservable(100)
 
     return (
         <ReactiveMotionDiv
@@ -429,7 +429,7 @@ function Component() {
         >
             ...
         </ReactiveMotionDiv>
-    );
+    )
 }
 ```
 
@@ -438,24 +438,24 @@ function Component() {
 This is a single HOC with the functionality of both `observer` and `reactive`. They both run the same function under the hood, with slightly different options, so this is the optimal way to have one HOC that does both at once.
 
 ```js
-import { observable } from '@legendapp/state';
-import { reactiveObserver } from '@legendapp/state/react';
+import { observable } from '@legendapp/state'
+import { reactiveObserver } from '@legendapp/state/react'
 
-const name$ = observable('Annyong');
-const isSignedIn$ = observable(false);
+const name$ = observable('Annyong')
+const isSignedIn$ = observable(false)
 
 const Component = reactiveObserver(function Component({ message }) {
-    const name = name$.get();
+    const name = name$.get()
 
     return (
         <div>
             {message} {name}
         </div>
-    );
-});
+    )
+})
 
 function App() {
-    return <Component $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')} />;
+    return <Component $message={() => (isSignedIn$.get() ? 'Hello' : 'Goodbye')} />
 }
 ```
 
@@ -464,14 +464,14 @@ function App() {
 `reactiveComponents` makes multiple reactive components at once. You can use this to create your own internal library of reactive components, or to wrap UI libraries that have multiple components in a namespace like `Modal.Header` and `Modal.Footer`.
 
 ```js
-import { reactiveComponents } from '@legendapp/state/react';
-import { motion } from 'framer-motion';
+import { reactiveComponents } from '@legendapp/state/react'
+import { motion } from 'framer-motion'
 
-const ReactiveMotion = reactiveComponents(motion);
+const ReactiveMotion = reactiveComponents(motion)
 
 function Component() {
     // This component renders only once
-    const width$ = useObservable(100);
+    const width$ = useObservable(100)
 
     return (
         <ReactiveMotion.div
@@ -481,6 +481,6 @@ function Component() {
         >
             ...
         </ReactiveMotion.div>
-    );
+    )
 }
 ```


### PR DESCRIPTION
- reworded a few things
- added a few more examples for fine-grained reactivity

an issue was present in the docs where the "why?" section was not forked correctly from the main repo.
@jmeistrich please add the `why?.mdx` back in production.