### PR TITLE
Typo in useUnmount example snippet

### DIFF
--- a/docs/3-react/2-react-API.mdx
+++ b/docs/3-react/2-react-API.mdx
@@ -258,10 +258,10 @@ const Component = () => {
 Like the `useMount` hook, `useUnmount` is just `useEffect` under the hood.
 
 ```jsx
-import { useMount } from "@legendapp/state/react"
+import { useUnmount } from "@legendapp/state/react"
 
 const Component = () => {
-    useMount(() => console.log('mounted'))
+    useUnmount(() => console.log('unmounted'))
 }
 ```
 


### PR DESCRIPTION
Nothing special about this PR - just noticed that the code snippet for useUnmount was the same as the useMount so corrected it 