### PR TITLE
Migrated to Tanstack Query v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.1.4
+- Fix: observe not running reaction if selector is an object or array
+
+## 2.1.3
+- Fix: An occasional error in sync get function
+
+## 2.1.2
+- Fix: Local cache was not saving Map/Set correctly
+
 ## 2.1.1
 - Feat: usePauseProvider to pause/resume all updates under a context
 

--- a/index.ts
+++ b/index.ts
@@ -56,7 +56,7 @@ export { ObservablePrimitiveClass } from './src/ObservablePrimitive';
 // Internal:
 import { get, getProxy, observableFns, peek, set } from './src/ObservableObject';
 import { ensureNodeValue, findIDKey, getNode, globalState, optimized, setNodeValue, symbolDelete } from './src/globals';
-import { getPathType, setAtPath } from './src/helpers';
+import { getPathType, setAtPath, initializePathType } from './src/helpers';
 
 export const internal = {
     ensureNodeValue,
@@ -66,6 +66,7 @@ export const internal = {
     getPathType,
     getProxy,
     globalState,
+    initializePathType,
     observableFns,
     optimized,
     peek,

--- a/index.ts
+++ b/index.ts
@@ -56,13 +56,14 @@ export { ObservablePrimitiveClass } from './src/ObservablePrimitive';
 // Internal:
 import { get, getProxy, observableFns, peek, set } from './src/ObservableObject';
 import { ensureNodeValue, findIDKey, getNode, globalState, optimized, setNodeValue, symbolDelete } from './src/globals';
-import { setAtPath } from './src/helpers';
+import { getPathType, setAtPath } from './src/helpers';
 
 export const internal = {
     ensureNodeValue,
     findIDKey,
     get,
     getNode,
+    getPathType,
     getProxy,
     globalState,
     observableFns,

--- a/index.ts
+++ b/index.ts
@@ -56,9 +56,10 @@ export { ObservablePrimitiveClass } from './src/ObservablePrimitive';
 // Internal:
 import { get, getProxy, observableFns, peek, set } from './src/ObservableObject';
 import { ensureNodeValue, findIDKey, getNode, globalState, optimized, setNodeValue, symbolDelete } from './src/globals';
-import { getPathType, setAtPath, initializePathType } from './src/helpers';
+import { getPathType, setAtPath, initializePathType, safeParse, safeStringify, clone } from './src/helpers';
 
 export const internal = {
+    clone,
     ensureNodeValue,
     findIDKey,
     get,
@@ -70,6 +71,8 @@ export const internal = {
     observableFns,
     optimized,
     peek,
+    safeParse,
+    safeStringify,
     set,
     setAtPath,
     setNodeValue,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@legendapp/state",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@legendapp/state",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "license": "MIT",
             "dependencies": {
                 "use-sync-external-store": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@legendapp/state",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@legendapp/state",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "license": "MIT",
             "dependencies": {
                 "use-sync-external-store": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
                 "@types/react-dom": "^18.0.8",
                 "@types/react-native": "^0.70.6",
                 "@types/use-sync-external-store": "^0.0.3",
-                "@typescript-eslint/eslint-plugin": "^5.48.0",
-                "@typescript-eslint/parser": "^5.48.0",
+                "@typescript-eslint/eslint-plugin": "^6.13.1",
+                "@typescript-eslint/parser": "^6.13.1",
                 "babel-jest": "^29.4.1",
                 "commitlint": "^17.4.4",
                 "eslint": "^8.45.0",
@@ -54,11 +54,19 @@
                 "rollup": "^3.2.5",
                 "ts-jest": "^29.1.1",
                 "tslib": "^2.4.1",
-                "typescript": "^5.1.6"
+                "typescript": "^5.3.2"
             },
             "engines": {
                 "node": ">=16.6.0",
                 "npm": ">=8.11.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -6102,9 +6110,9 @@
             }
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
         },
         "node_modules/@types/minimist": {
@@ -6179,9 +6187,9 @@
             "dev": true
         },
         "node_modules/@types/semver": {
-            "version": "7.3.13",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+            "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
             "dev": true
         },
         "node_modules/@types/stack-utils": {
@@ -6227,31 +6235,33 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz",
-            "integrity": "sha512-SVLafp0NXpoJY7ut6VFVUU9I+YeFsDzeQwtK0WZ+xbRN3mtxJ08je+6Oi2N89qDn087COdO0u3blKZNv9VetRQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.1.tgz",
+            "integrity": "sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.48.0",
-                "@typescript-eslint/type-utils": "5.48.0",
-                "@typescript-eslint/utils": "5.48.0",
+                "@eslint-community/regexpp": "^4.5.1",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/type-utils": "6.13.1",
+                "@typescript-eslint/utils": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4",
-                "ignore": "^5.2.0",
-                "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
+                "graphemer": "^1.4.0",
+                "ignore": "^5.2.4",
+                "natural-compare": "^1.4.0",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^5.0.0",
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+                "eslint": "^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -6260,9 +6270,9 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -6275,25 +6285,26 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
-            "integrity": "sha512-1mxNA8qfgxX8kBvRDIHEzrRGrKHQfQlbW6iHyfHYS0Q4X1af+S6mkLNtgCOsGVl8+/LUPrqdHMssAemkrQ01qg==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.1.tgz",
+            "integrity": "sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.48.0",
-                "@typescript-eslint/types": "5.48.0",
-                "@typescript-eslint/typescript-estree": "5.48.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                "eslint": "^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -6302,16 +6313,16 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.0.tgz",
-            "integrity": "sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.1.tgz",
+            "integrity": "sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.48.0",
-                "@typescript-eslint/visitor-keys": "5.48.0"
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -6319,25 +6330,25 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
-            "integrity": "sha512-vbtPO5sJyFjtHkGlGK4Sthmta0Bbls4Onv0bEqOGm7hP9h8UpRsHJwsrCiWtCUndTRNQO/qe6Ijz9rnT/DB+7g==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.1.tgz",
+            "integrity": "sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.48.0",
-                "@typescript-eslint/utils": "5.48.0",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "@typescript-eslint/utils": "6.13.1",
                 "debug": "^4.3.4",
-                "tsutils": "^3.21.0"
+                "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "*"
+                "eslint": "^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -6346,12 +6357,12 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.0.tgz",
-            "integrity": "sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.1.tgz",
+            "integrity": "sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==",
             "dev": true,
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -6359,21 +6370,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.0.tgz",
-            "integrity": "sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.1.tgz",
+            "integrity": "sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.48.0",
-                "@typescript-eslint/visitor-keys": "5.48.0",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -6386,9 +6397,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -6401,57 +6412,34 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.0.tgz",
-            "integrity": "sha512-x2jrMcPaMfsHRRIkL+x96++xdzvrdBCnYRd5QiW5Wgo1OB4kDYPbC1XjWP/TNqlfK93K/lUL92erq5zPLgFScQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.1.tgz",
+            "integrity": "sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==",
             "dev": true,
             "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.48.0",
-                "@typescript-eslint/types": "5.48.0",
-                "@typescript-eslint/typescript-estree": "5.48.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
-                "semver": "^7.3.7"
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@types/json-schema": "^7.0.12",
+                "@types/semver": "^7.5.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "semver": "^7.5.4"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
+                "eslint": "^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/@typescript-eslint/utils/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -6464,16 +6452,16 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.0.tgz",
-            "integrity": "sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.1.tgz",
+            "integrity": "sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.48.0",
-                "eslint-visitor-keys": "^3.3.0"
+                "@typescript-eslint/types": "6.13.1",
+                "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -9435,33 +9423,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "dependencies": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "engines": {
-                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=5"
-            }
-        },
-        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/eslint-visitor-keys": {
@@ -15169,12 +15130,6 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "node_modules/natural-compare-lite": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-            "dev": true
-        },
         "node_modules/negotiator": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -17072,18 +17027,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
             }
         },
         "node_modules/regexpu-core": {
@@ -19283,6 +19226,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ts-api-utils": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+            "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.13.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.2.0"
+            }
+        },
         "node_modules/ts-jest": {
             "version": "29.1.1",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
@@ -19399,27 +19354,6 @@
             "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
             "dev": true
         },
-        "node_modules/tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^1.8.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            },
-            "peerDependencies": {
-                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-            }
-        },
-        "node_modules/tsutils/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
-        },
         "node_modules/type-check": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -19483,9 +19417,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+            "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -24906,9 +24840,9 @@
             }
         },
         "@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
         },
         "@types/minimist": {
@@ -24983,9 +24917,9 @@
             "dev": true
         },
         "@types/semver": {
-            "version": "7.3.13",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+            "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
             "dev": true
         },
         "@types/stack-utils": {
@@ -25031,26 +24965,28 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz",
-            "integrity": "sha512-SVLafp0NXpoJY7ut6VFVUU9I+YeFsDzeQwtK0WZ+xbRN3mtxJ08je+6Oi2N89qDn087COdO0u3blKZNv9VetRQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.1.tgz",
+            "integrity": "sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.48.0",
-                "@typescript-eslint/type-utils": "5.48.0",
-                "@typescript-eslint/utils": "5.48.0",
+                "@eslint-community/regexpp": "^4.5.1",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/type-utils": "6.13.1",
+                "@typescript-eslint/utils": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4",
-                "ignore": "^5.2.0",
-                "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
+                "graphemer": "^1.4.0",
+                "ignore": "^5.2.4",
+                "natural-compare": "^1.4.0",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
             },
             "dependencies": {
                 "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -25059,64 +24995,65 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
-            "integrity": "sha512-1mxNA8qfgxX8kBvRDIHEzrRGrKHQfQlbW6iHyfHYS0Q4X1af+S6mkLNtgCOsGVl8+/LUPrqdHMssAemkrQ01qg==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.1.tgz",
+            "integrity": "sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.48.0",
-                "@typescript-eslint/types": "5.48.0",
-                "@typescript-eslint/typescript-estree": "5.48.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.0.tgz",
-            "integrity": "sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.1.tgz",
+            "integrity": "sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.48.0",
-                "@typescript-eslint/visitor-keys": "5.48.0"
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
-            "integrity": "sha512-vbtPO5sJyFjtHkGlGK4Sthmta0Bbls4Onv0bEqOGm7hP9h8UpRsHJwsrCiWtCUndTRNQO/qe6Ijz9rnT/DB+7g==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.1.tgz",
+            "integrity": "sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "5.48.0",
-                "@typescript-eslint/utils": "5.48.0",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "@typescript-eslint/utils": "6.13.1",
                 "debug": "^4.3.4",
-                "tsutils": "^3.21.0"
+                "ts-api-utils": "^1.0.1"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.0.tgz",
-            "integrity": "sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.1.tgz",
+            "integrity": "sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.0.tgz",
-            "integrity": "sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.1.tgz",
+            "integrity": "sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.48.0",
-                "@typescript-eslint/visitor-keys": "5.48.0",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
             },
             "dependencies": {
                 "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -25125,41 +25062,24 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.0.tgz",
-            "integrity": "sha512-x2jrMcPaMfsHRRIkL+x96++xdzvrdBCnYRd5QiW5Wgo1OB4kDYPbC1XjWP/TNqlfK93K/lUL92erq5zPLgFScQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.1.tgz",
+            "integrity": "sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==",
             "dev": true,
             "requires": {
-                "@types/json-schema": "^7.0.9",
-                "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.48.0",
-                "@typescript-eslint/types": "5.48.0",
-                "@typescript-eslint/typescript-estree": "5.48.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
-                "semver": "^7.3.7"
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@types/json-schema": "^7.0.12",
+                "@types/semver": "^7.5.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "semver": "^7.5.4"
             },
             "dependencies": {
-                "eslint-scope": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-                    "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.3.0",
-                        "estraverse": "^4.1.1"
-                    }
-                },
-                "estraverse": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-                    "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-                    "dev": true
-                },
                 "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -25168,13 +25088,13 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.0.tgz",
-            "integrity": "sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.1.tgz",
+            "integrity": "sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.48.0",
-                "eslint-visitor-keys": "^3.3.0"
+                "@typescript-eslint/types": "6.13.1",
+                "eslint-visitor-keys": "^3.4.1"
             }
         },
         "abab": {
@@ -27571,23 +27491,6 @@
             "requires": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
-            }
-        },
-        "eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "requires": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-                    "dev": true
-                }
             }
         },
         "eslint-visitor-keys": {
@@ -31851,12 +31754,6 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "natural-compare-lite": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-            "dev": true
-        },
         "negotiator": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -33290,12 +33187,6 @@
                 "define-properties": "^1.2.0",
                 "functions-have-names": "^1.2.3"
             }
-        },
-        "regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true
         },
         "regexpu-core": {
             "version": "5.2.1",
@@ -34951,6 +34842,13 @@
             "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
             "dev": true
         },
+        "ts-api-utils": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+            "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+            "dev": true,
+            "requires": {}
+        },
         "ts-jest": {
             "version": "29.1.1",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
@@ -35013,23 +34911,6 @@
             "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
             "dev": true
         },
-        "tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
-                }
-            }
-        },
         "type-check": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -35078,9 +34959,9 @@
             }
         },
         "typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+            "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
             "dev": true
         },
         "typeson": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@legendapp/state",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@legendapp/state",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "license": "MIT",
             "dependencies": {
                 "use-sync-external-store": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@rollup/plugin-typescript": "^9.0.2",
                 "@swc/cli": "^0.1.57",
                 "@swc/core": "^1.3.14",
-                "@tanstack/react-query": "^4.14.6",
+                "@tanstack/react-query": "^5.17.19",
                 "@testing-library/jest-dom": "^5.16.5",
                 "@testing-library/react": "^14.0.0",
                 "@types/jest": "^29.5.3",
@@ -5829,9 +5829,9 @@
             }
         },
         "node_modules/@tanstack/query-core": {
-            "version": "4.14.5",
-            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.14.5.tgz",
-            "integrity": "sha512-Su1AyrPb6xnm7wXTvpN5tt+B7LViYSh9k04vvuc6+eMVH0HkE9ktZTXibRrTvV83BI1KP5MG7v/k90ne/4zQzw==",
+            "version": "5.17.19",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.17.19.tgz",
+            "integrity": "sha512-Lzw8FUtnLCc9Jwz0sw9xOjZB+/mCCmJev38v2wHMUl/ioXNIhnNWeMxu0NKUjIhAd62IRB3eAtvxAGDJ55UkyA==",
             "dev": true,
             "funding": {
                 "type": "github",
@@ -5839,30 +5839,19 @@
             }
         },
         "node_modules/@tanstack/react-query": {
-            "version": "4.14.6",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.14.6.tgz",
-            "integrity": "sha512-ubx49AeV0SXfbt4mZmb0JlJa1PRXynGm+uorJhM50HVDppt/SjcOUNK5kptEWBRzTjKVS9KhpoMkKKJ/ZzuBFQ==",
+            "version": "5.17.19",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.17.19.tgz",
+            "integrity": "sha512-qaQENB6/03Gj3dFZGvdmUoqeUGlGm7P1p0RmaR04Bf1Ib1T9lLGimcC9T3oCFbrx0b2ZF21ngjFZNjj9uPJMcg==",
             "dev": true,
             "dependencies": {
-                "@tanstack/query-core": "4.14.5",
-                "use-sync-external-store": "^1.2.0"
+                "@tanstack/query-core": "5.17.19"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
             },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-native": "*"
-            },
-            "peerDependenciesMeta": {
-                "react-dom": {
-                    "optional": true
-                },
-                "react-native": {
-                    "optional": true
-                }
+                "react": "^18.0.0"
             }
         },
         "node_modules/@testing-library/dom": {
@@ -24606,19 +24595,18 @@
             }
         },
         "@tanstack/query-core": {
-            "version": "4.14.5",
-            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.14.5.tgz",
-            "integrity": "sha512-Su1AyrPb6xnm7wXTvpN5tt+B7LViYSh9k04vvuc6+eMVH0HkE9ktZTXibRrTvV83BI1KP5MG7v/k90ne/4zQzw==",
+            "version": "5.17.19",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.17.19.tgz",
+            "integrity": "sha512-Lzw8FUtnLCc9Jwz0sw9xOjZB+/mCCmJev38v2wHMUl/ioXNIhnNWeMxu0NKUjIhAd62IRB3eAtvxAGDJ55UkyA==",
             "dev": true
         },
         "@tanstack/react-query": {
-            "version": "4.14.6",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.14.6.tgz",
-            "integrity": "sha512-ubx49AeV0SXfbt4mZmb0JlJa1PRXynGm+uorJhM50HVDppt/SjcOUNK5kptEWBRzTjKVS9KhpoMkKKJ/ZzuBFQ==",
+            "version": "5.17.19",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.17.19.tgz",
+            "integrity": "sha512-qaQENB6/03Gj3dFZGvdmUoqeUGlGm7P1p0RmaR04Bf1Ib1T9lLGimcC9T3oCFbrx0b2ZF21ngjFZNjj9uPJMcg==",
             "dev": true,
             "requires": {
-                "@tanstack/query-core": "4.14.5",
-                "use-sync-external-store": "^1.2.0"
+                "@tanstack/query-core": "5.17.19"
             }
         },
         "@testing-library/dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@legendapp/state",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@legendapp/state",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "license": "MIT",
             "dependencies": {
                 "use-sync-external-store": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "@rollup/plugin-typescript": "^9.0.2",
         "@swc/cli": "^0.1.57",
         "@swc/core": "^1.3.14",
-        "@tanstack/react-query": "^4.14.6",
+        "@tanstack/react-query": "^5.17.19",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@types/jest": "^29.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@legendapp/state",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "legend-state",
     "sideEffects": false,
     "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@legendapp/state",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "legend-state",
     "sideEffects": false,
     "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@legendapp/state",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "legend-state",
     "sideEffects": false,
     "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@legendapp/state",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "legend-state",
     "sideEffects": false,
     "private": true,

--- a/package.json
+++ b/package.json
@@ -112,8 +112,8 @@
         "@types/react-dom": "^18.0.8",
         "@types/react-native": "^0.70.6",
         "@types/use-sync-external-store": "^0.0.3",
-        "@typescript-eslint/eslint-plugin": "^5.48.0",
-        "@typescript-eslint/parser": "^5.48.0",
+        "@typescript-eslint/eslint-plugin": "^6.13.1",
+        "@typescript-eslint/parser": "^6.13.1",
         "babel-jest": "^29.4.1",
         "commitlint": "^17.4.4",
         "eslint": "^8.45.0",
@@ -135,7 +135,7 @@
         "rollup": "^3.2.5",
         "ts-jest": "^29.1.1",
         "tslib": "^2.4.1",
-        "typescript": "^5.1.6"
+        "typescript": "^5.3.2"
     },
     "peerDependencies": {
         "react": ">=16.8.0"

--- a/src/ObservableObject.ts
+++ b/src/ObservableObject.ts
@@ -719,6 +719,10 @@ function updateNodesAndNotify(
     // Make sure we don't call too many listeners for ever property set
     beginBatch();
 
+    if (isPrim === undefined) {
+        isPrim = isPrimitive(newValue);
+    }
+
     let hasADiff = isPrim;
     let whenOptimizedOnlyIf = false;
     // If new value is an object or array update notify down the tree

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -206,3 +206,38 @@ export function setSilently(obs: ObservableReadable, newValue: any) {
     const node = getNode(obs);
     return setNodeValue(node, newValue).newValue;
 }
+
+export function getPathType(value: any): TypeAtPath {
+    return isArray(value) ? 'array' : value instanceof Map ? 'map' : value instanceof Set ? 'set' : 'object';
+}
+
+function replacer(key: string, value: any) {
+    if (value instanceof Map) {
+        return {
+            dataType: 'Map',
+            value: Array.from(value.entries()), // or with spread: value: [...value]
+        };
+    } else if (value instanceof Set) {
+        return {
+            dataType: 'Set',
+            value: Array.from(value), // or with spread: value: [...value]
+        };
+    } else {
+        return value;
+    }
+}
+
+function reviver(key: string, value: any) {
+    if (typeof value === 'object' && value !== null) {
+        if (value.dataType === 'Map') {
+            return new Map(value.value);
+        } else if (value.dataType === 'Set') {
+            return new Set(value.value);
+        }
+    }
+    return value;
+}
+
+export function clone(value: any) {
+    return JSON.parse(JSON.stringify(value, replacer), reviver);
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -82,7 +82,7 @@ export function setAtPath<T extends object>(
                 }
                 break;
             } else if (o[p] === undefined || o[p] === null) {
-                o[p] = pathTypes[i] === 'array' ? [] : {};
+                o[p] = initializePathType(pathTypes[i]);
             }
             o = o[p];
             if (oFull) {
@@ -98,7 +98,7 @@ export function setAtPath<T extends object>(
 export function setInObservableAtPath(
     obs: ObservableWriteable,
     path: string[],
-    pathTypes: string[],
+    pathTypes: TypeAtPath[],
     value: any,
     mode: 'assign' | 'set',
 ) {
@@ -106,8 +106,8 @@ export function setInObservableAtPath(
     let v = value;
     for (let i = 0; i < path.length; i++) {
         const p = path[i];
-        if (!o.peek()[p] && pathTypes[i] === 'array') {
-            o[p].set([]);
+        if (!o.peek()[p]) {
+            o[p].set(initializePathType(pathTypes[i]));
         }
         o = o[p];
         v = v[p];
@@ -180,7 +180,7 @@ export function constructObjectWithPath(path: string[], pathTypes: TypeAtPath[],
         let o: Record<string, any> = (out = {});
         for (let i = 0; i < path.length; i++) {
             const p = path[i];
-            o[p] = i === path.length - 1 ? value : pathTypes[i] === 'array' ? [] : {};
+            o[p] = i === path.length - 1 ? value : initializePathType(pathTypes[i]);
             o = o[p];
         }
     } else {
@@ -193,7 +193,7 @@ export function deconstructObjectWithPath(path: string[], pathTypes: TypeAtPath[
     let o = value;
     for (let i = 0; i < path.length; i++) {
         const p = path[i];
-        o = o ? o[p] : pathTypes[i] === 'array' ? [] : {};
+        o = o ? o[p] : initializePathType(pathTypes[i]);
     }
 
     return o;
@@ -211,7 +211,20 @@ export function getPathType(value: any): TypeAtPath {
     return isArray(value) ? 'array' : value instanceof Map ? 'map' : value instanceof Set ? 'set' : 'object';
 }
 
-function replacer(key: string, value: any) {
+export function initializePathType(pathType: TypeAtPath): any {
+    switch (pathType) {
+        case 'array':
+            return [];
+        case 'object':
+            return {};
+        case 'map':
+            return new Map();
+        case 'set':
+            return new Set();
+    }
+}
+
+function replacer(_: string, value: any) {
     if (value instanceof Map) {
         return {
             dataType: 'Map',
@@ -227,7 +240,7 @@ function replacer(key: string, value: any) {
     }
 }
 
-function reviver(key: string, value: any) {
+function reviver(_: string, value: any) {
     if (typeof value === 'object' && value !== null) {
         if (value.dataType === 'Map') {
             return new Map(value.value);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -227,12 +227,12 @@ export function initializePathType(pathType: TypeAtPath): any {
 function replacer(_: string, value: any) {
     if (value instanceof Map) {
         return {
-            dataType: 'Map',
+            __LSType: 'Map',
             value: Array.from(value.entries()), // or with spread: value: [...value]
         };
     } else if (value instanceof Set) {
         return {
-            dataType: 'Set',
+            __LSType: 'Set',
             value: Array.from(value), // or with spread: value: [...value]
         };
     } else {
@@ -241,16 +241,22 @@ function replacer(_: string, value: any) {
 }
 
 function reviver(_: string, value: any) {
-    if (typeof value === 'object' && value !== null) {
-        if (value.dataType === 'Map') {
+    if (typeof value === 'object' && value) {
+        if (value.__LSType === 'Map') {
             return new Map(value.value);
-        } else if (value.dataType === 'Set') {
+        } else if (value.__LSType === 'Set') {
             return new Set(value.value);
         }
     }
     return value;
 }
 
+export function safeStringify(value: any) {
+    return JSON.stringify(value, replacer);
+}
+export function safeParse(value: any) {
+    return JSON.parse(value, reviver);
+}
 export function clone(value: any) {
-    return JSON.parse(JSON.stringify(value, replacer), reviver);
+    return safeParse(safeStringify(value));
 }

--- a/src/observableInterfaces.ts
+++ b/src/observableInterfaces.ts
@@ -159,7 +159,7 @@ export type QueryByModified<T> =
           '*'?: boolean;
       };
 
-export type TypeAtPath = 'object' | 'array';
+export type TypeAtPath = 'object' | 'array' | 'map' | 'set';
 
 export interface Change {
     path: string[];

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -59,7 +59,7 @@ export function observe<T>(
         if (
             reaction &&
             (e.num > 0 || !isEvent(selectorOrRun as any)) &&
-            (e.previous !== e.value || options?.fromComputed)
+            (e.previous !== e.value || options?.fromComputed || typeof e.value === 'object')
         ) {
             reaction(e);
         }

--- a/src/persist-plugins/async-storage.ts
+++ b/src/persist-plugins/async-storage.ts
@@ -4,12 +4,14 @@ import type {
     ObservablePersistenceConfigLocalGlobalOptions,
     PersistMetadata,
 } from '@legendapp/state';
-import { isArray, setAtPath } from '@legendapp/state';
+import { isArray, setAtPath, internal } from '@legendapp/state';
 import type { AsyncStorageStatic } from '@react-native-async-storage/async-storage';
 
 const MetadataSuffix = '__m';
 
 let AsyncStorage: AsyncStorageStatic;
+
+const { safeParse, safeStringify } = internal;
 
 export class ObservablePersistAsyncStorage implements ObservablePersistLocal {
     private data: Record<string, any> = {};
@@ -33,7 +35,7 @@ export class ObservablePersistAsyncStorage implements ObservablePersistLocal {
                     const values = await AsyncStorage.multiGet(tables);
 
                     values.forEach(([table, value]) => {
-                        this.data[table] = value ? JSON.parse(value) : undefined;
+                        this.data[table] = value ? safeParse(value) : undefined;
                     });
                 }
             } catch (e) {
@@ -48,7 +50,7 @@ export class ObservablePersistAsyncStorage implements ObservablePersistLocal {
             try {
                 return (async () => {
                     const value = await AsyncStorage.getItem(table);
-                    this.data[table] = value ? JSON.parse(value) : undefined;
+                    this.data[table] = value ? safeParse(value) : undefined;
                 })();
             } catch {
                 console.error('[legend-state] ObservablePersistLocalAsyncStorage failed to parse', table);
@@ -92,7 +94,7 @@ export class ObservablePersistAsyncStorage implements ObservablePersistLocal {
         const v = this.data[table];
 
         if (v !== undefined && v !== null) {
-            return AsyncStorage.setItem(table, JSON.stringify(v));
+            return AsyncStorage.setItem(table, safeStringify(v));
         } else {
             return AsyncStorage.removeItem(table);
         }

--- a/src/persist-plugins/firebase.ts
+++ b/src/persist-plugins/firebase.ts
@@ -38,7 +38,7 @@ import {
     startAt,
     update,
 } from 'firebase/database';
-const { symbolDelete } = internal;
+const { symbolDelete, getPathType } = internal;
 const { observablePersistConfiguration } = internalPersist;
 
 function clone(obj: any) {
@@ -231,7 +231,7 @@ class ObservablePersistFirebaseBase implements ObservablePersistRemoteClass {
                 const q =
                     queryByModified[key as keyof typeof queryByModified] || (queryByModified as { '*': boolean })['*'];
                 const pathChild = path.concat(key);
-                const pathTypesChild = pathTypes.concat(isArray(o.peek()) ? 'array' : 'object');
+                const pathTypesChild = pathTypes.concat(getPathType(o.peek()));
                 let dateModified: number | undefined = undefined;
 
                 if (isObject(q)) {

--- a/src/persist-plugins/firebase.ts
+++ b/src/persist-plugins/firebase.ts
@@ -38,12 +38,9 @@ import {
     startAt,
     update,
 } from 'firebase/database';
-const { symbolDelete, getPathType } = internal;
+const { symbolDelete, getPathType, clone } = internal;
 const { observablePersistConfiguration } = internalPersist;
 
-function clone(obj: any) {
-    return obj === undefined || obj === null ? obj : JSON.parse(JSON.stringify(obj));
-}
 function getDateModifiedKey(dateModifiedKey: string | undefined) {
     return dateModifiedKey || observablePersistConfiguration.remoteOptions?.dateModifiedKey || '@';
 }
@@ -615,10 +612,7 @@ class ObservablePersistFirebaseBase implements ObservablePersistRemoteClass {
         saveState.numSavesPending.set((v) => v + 1);
 
         if (pendingSaves.size > 0) {
-            const batches = JSON.parse(JSON.stringify(this._constructBatchesForSave(pendingSaves))) as Record<
-                string,
-                any
-            >[];
+            const batches = clone(this._constructBatchesForSave(pendingSaves)) as Record<string, any>[];
 
             saveState.savingSaves = pendingSaves;
 

--- a/src/persist-plugins/local-storage.ts
+++ b/src/persist-plugins/local-storage.ts
@@ -1,7 +1,9 @@
 import type { Change, ObservablePersistLocal, PersistMetadata } from '@legendapp/state';
-import { setAtPath } from '@legendapp/state';
+import { setAtPath, internal } from '@legendapp/state';
 
 const MetadataSuffix = '__m';
+
+const { safeParse, safeStringify } = internal;
 
 class ObservablePersistLocalStorageBase implements ObservablePersistLocal {
     private data: Record<string, any> = {};
@@ -14,7 +16,7 @@ class ObservablePersistLocalStorageBase implements ObservablePersistLocal {
         if (this.data[table] === undefined) {
             try {
                 const value = this.storage.getItem(table);
-                this.data[table] = value ? JSON.parse(value) : undefined;
+                this.data[table] = value ? safeParse(value) : undefined;
             } catch {
                 console.error('[legend-state] ObservablePersistLocalStorage failed to parse', table);
             }
@@ -56,7 +58,7 @@ class ObservablePersistLocalStorageBase implements ObservablePersistLocal {
         const v = this.data[table];
 
         if (v !== undefined && v !== null) {
-            this.storage.setItem(table, JSON.stringify(v));
+            this.storage.setItem(table, safeStringify(v));
         } else {
             this.storage.removeItem(table);
         }

--- a/src/persist-plugins/mmkv.ts
+++ b/src/persist-plugins/mmkv.ts
@@ -1,9 +1,11 @@
 import type { Change, ObservablePersistLocal, PersistMetadata, PersistOptionsLocal } from '@legendapp/state';
-import { setAtPath } from '@legendapp/state';
+import { internal, setAtPath } from '@legendapp/state';
 import { MMKV } from 'react-native-mmkv';
 
 const symbolDefault = Symbol();
 const MetadataSuffix = '__m';
+
+const { safeParse, safeStringify } = internal;
 
 export class ObservablePersistMMKV implements ObservablePersistLocal {
     private data: Record<string, any> = {};
@@ -21,7 +23,7 @@ export class ObservablePersistMMKV implements ObservablePersistLocal {
         if (this.data[table] === undefined) {
             try {
                 const value = storage.getString(table);
-                this.data[table] = value ? JSON.parse(value) : undefined;
+                this.data[table] = value ? safeParse(value) : undefined;
             } catch {
                 console.error('[legend-state] MMKV failed to parse', table);
             }
@@ -77,7 +79,7 @@ export class ObservablePersistMMKV implements ObservablePersistLocal {
         const v = this.data[table];
         if (v !== undefined) {
             try {
-                storage.set(table, JSON.stringify(v));
+                storage.set(table, safeStringify(v));
             } catch (err) {
                 console.error(err);
             }

--- a/src/persist-plugins/query.ts
+++ b/src/persist-plugins/query.ts
@@ -12,7 +12,6 @@ import {
     QueryObserver,
     UseBaseQueryOptions,
     UseMutationOptions,
-    notifyManager,
     useQueryClient,
 } from '@tanstack/react-query';
 
@@ -52,17 +51,17 @@ export function persistPluginQuery<TObs, TQueryFnData, TError, TData, TQueryData
     );
 
     // Include callbacks in batch renders
-    if (defaultedOptions.onError) {
-        defaultedOptions.onError = notifyManager.batchCalls(defaultedOptions.onError);
-    }
+    // if (defaultedOptions.onError) {
+    //     defaultedOptions.onError = notifyManager.batchCalls(defaultedOptions.onError);
+    // }
 
-    if (defaultedOptions.onSuccess) {
-        defaultedOptions.onSuccess = notifyManager.batchCalls(defaultedOptions.onSuccess);
-    }
+    // if (defaultedOptions.onSuccess) {
+    //     defaultedOptions.onSuccess = notifyManager.batchCalls(defaultedOptions.onSuccess);
+    // }
 
-    if (defaultedOptions.onSettled) {
-        defaultedOptions.onSettled = notifyManager.batchCalls(defaultedOptions.onSettled);
-    }
+    // if (defaultedOptions.onSettled) {
+    //     defaultedOptions.onSettled = notifyManager.batchCalls(defaultedOptions.onSettled);
+    // }
 
     const Observer = type === 'Query' ? QueryObserver : (InfiniteQueryObserver as typeof QueryObserver);
 

--- a/src/persist/fieldTransformer.ts
+++ b/src/persist/fieldTransformer.ts
@@ -7,7 +7,10 @@ import {
     isString,
     symbolDelete,
     TypeAtPath,
+    internal,
 } from '@legendapp/state';
+
+const { initializePathType } = internal;
 
 let validateMap: (map: Record<string, any>) => void;
 
@@ -15,7 +18,7 @@ export function transformPath(path: string[], pathTypes: TypeAtPath[], map: Reco
     const data: Record<string, any> = {};
     let d: Record<string, any> | null = data;
     for (let i = 0; i < path.length; i++) {
-        d = d![path[i]] = i === path.length - 1 ? null : pathTypes[i] === 'array' ? [] : {};
+        d = d![path[i]] = i === path.length - 1 ? null : initializePathType(pathTypes[i]);
     }
     let value = transformObject(data, map);
     const pathOut = [];

--- a/src/persist/persistObservable.ts
+++ b/src/persist/persistObservable.ts
@@ -686,7 +686,7 @@ export function persistObservable<T extends WithoutState>(
             if (!isSynced) {
                 isSynced = true;
                 const dateModified = metadatas.get(obs)?.modified;
-                const get = localState.persistenceRemote!.get;
+                const get = localState.persistenceRemote!.get?.bind(localState.persistenceRemote);
                 if (get) {
                     get({
                         state: syncState,

--- a/src/react/reactive-observer.tsx
+++ b/src/react/reactive-observer.tsx
@@ -174,7 +174,7 @@ export function reactiveComponents<P extends Record<string, FC>>(components: P):
         {},
         {
             get(target: Record<string, any>, p: string) {
-                if (!target[p]) {
+                if (!target[p] && components[p]) {
                     target[p] = createReactiveComponent(components[p], false, true) as FC<ShapeWith$<P>>;
                 }
 

--- a/src/react/useObservable.ts
+++ b/src/react/useObservable.ts
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
  *
  * @param initialValue The initial value of the observable or a function that returns the initial value
  *
- * @see https://www.legendapp.com/dev/state/react/#useObservable
+ * @see https://legendapp.com/open-source/state/react/react-api/#useobservable
  */
 export function useObservable<T>(initialValue?: T | (() => T) | (() => Promise<T>)): Observable<T> {
     // Create the observable from the default value

--- a/tests/mapset.test.ts
+++ b/tests/mapset.test.ts
@@ -71,7 +71,7 @@ describe('Map is observable', () => {
         expect(handler).toHaveBeenCalledWith('value2', 'value', [
             { path: [], pathTypes: [], prevAtPath: 'value', valueAtPath: 'value2' },
         ]);
-        expect(handler2).toHaveBeenCalledWith(obs.test.peek(), { key: 'value' }, [
+        expect(handler2).toHaveBeenCalledWith(obs.test.peek(), new Map([['key', 'value']]), [
             { path: ['key'], pathTypes: ['object'], prevAtPath: 'value', valueAtPath: 'value2' },
         ]);
     });
@@ -159,5 +159,39 @@ describe('Set default behavior', () => {
     test('Set size is observable', () => {
         const obs = observable({ test: new Set(['key']) });
         expect(obs.test.size.get()).toEqual(1);
+    });
+});
+
+describe('Map/Set pathTypes', () => {
+    test('Map changes have correct previous and pathTypes', () => {
+        const obs = observable({ test: new Map([['key', 'value']]) });
+        const handler = expectChangeHandler(obs);
+
+        obs.test.set('key', 'value2');
+
+        expect(handler).toHaveBeenCalledWith(
+            { test: new Map([['key', 'value2']]) },
+            { test: new Map([['key', 'value']]) },
+            [{ path: ['test', 'key'], pathTypes: ['map', 'object'], prevAtPath: 'value', valueAtPath: 'value2' }],
+        );
+    });
+    test('Set changes have correct previous and pathTypes', () => {
+        const obs = observable({ test: new Set(['key1', 'key2']) });
+        const handler = expectChangeHandler(obs);
+
+        obs.test.add('key3');
+
+        expect(handler).toHaveBeenCalledWith(
+            { test: new Set(['key1', 'key2', 'key3']) },
+            { test: new Set(['key1', 'key2']) },
+            [
+                {
+                    path: ['test'],
+                    pathTypes: ['set'],
+                    prevAtPath: new Set(['key1', 'key2']),
+                    valueAtPath: new Set(['key1', 'key2', 'key3']),
+                },
+            ],
+        );
     });
 });

--- a/tests/mapset.test.ts
+++ b/tests/mapset.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { isObservable } from '../src/helpers';
+import { isObservable, mergeIntoObservable } from '../src/helpers';
 import { observable } from '../src/observable';
 import { Change, ObservableReadable, TrackingType } from '../src/observableInterfaces';
 
@@ -193,5 +193,11 @@ describe('Map/Set pathTypes', () => {
                 },
             ],
         );
+    });
+    test('mergeIntoObservable with Map', () => {
+        const obs = observable({ test: undefined as unknown as Map<string, any> });
+
+        mergeIntoObservable(obs, { test: new Map([['key', 'value']]) });
+        expect(obs.test.peek()).toEqual(new Map([['key', 'value']]));
     });
 });

--- a/tests/persist.test.ts
+++ b/tests/persist.test.ts
@@ -1,9 +1,8 @@
 import 'fake-indexeddb/auto';
-import { transformOutData, persistObservable } from '../src/persist/persistObservable';
-import { ObservablePersistLocalStorage } from '../src/persist-plugins/local-storage';
-import { Change } from '../src/observableInterfaces';
-import { observe } from '../src/observe';
 import { observable } from '../src/observable';
+import { Change } from '../src/observableInterfaces';
+import { ObservablePersistLocalStorage } from '../src/persist-plugins/local-storage';
+import { persistObservable, transformOutData } from '../src/persist/persistObservable';
 import { when } from '../src/when';
 
 function promiseTimeout(time?: number) {

--- a/tests/tests.test.ts
+++ b/tests/tests.test.ts
@@ -2751,6 +2751,21 @@ describe('Observe', () => {
         obsOther.set(1);
         expect(count).toEqual(1);
     });
+    test('Observe with reaction and array', () => {
+        let lastLength = 0;
+        const state$ = observable({
+            arr: [1, 2, 3, 4],
+        });
+
+        observe(state$.arr, () => {
+            const num = state$.arr.peek();
+            lastLength = num.length;
+        });
+
+        expect(lastLength).toEqual(4);
+        state$.arr.push(10);
+        expect(lastLength).toEqual(5);
+    });
 });
 describe('Error detection', () => {
     test('Circular objects in set', () => {


### PR DESCRIPTION
I migrated Tanstack Query to v5.

Callback on queries were removed some I commented them out for now 
(see https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#callbacks-on-usequery-and-queryobserver-have-been-removed)

closes #210 