### PR TITLE
Adds an undoRedo() helper for undo / redo history

### DIFF
--- a/src/history/undoRedo.ts
+++ b/src/history/undoRedo.ts
@@ -1,0 +1,111 @@
+import { type ObservablePrimitive, internal, observable } from '@legendapp/state';
+
+type UndoRedoOptions = {
+    limit?: number;
+};
+
+/**
+ * Usage:
+ *
+ * Use this function to add undo/redo functionality to an observable.
+ *
+ * You can monitor how many undos or redos are available to enable/disable undo/redo
+ * UI elements with undo$ and redo$.
+ *
+ * If you undo and then make a change, it'll delete any redos and add the change, as expected.
+ *
+ * If you don't pass in a limit, it will keep all history. This means it can grow indefinitely.
+ *
+ * ```typescript
+ * const obs$ = observable({ test: 'hi', test2: 'a' });
+ * const { undo, redo, undos$, redos$, getHistory } = undoRedo(obs$, { limit: 40 });
+ * obs$.test.set('hello');
+ * undo();
+ * redo();
+ * // observables for # of undos/redos available
+ * undos$.get();
+ * redos$.get();
+ * ```
+ */
+export function undoRedo<T>(obs$: ObservablePrimitive<T>, options?: UndoRedoOptions) {
+    let history = [] as T[];
+    let historyPointer = 0;
+    let restoringFromHistory = false;
+
+    const undos$ = observable(0);
+    const redos$ = observable(0);
+
+    function updateUndoRedo() {
+        undos$.set(historyPointer);
+        redos$.set(history.length - historyPointer - 1);
+    }
+
+    obs$.onChange(({ getPrevious }) => {
+        // Don't save history if we're restoring from history.
+        if (restoringFromHistory) return;
+
+        // Don't save history if this is a remote change.
+        // History will be saved remotely by the client making the local change.
+        if (internal.globalState.isLoadingRemote || internal.globalState.isLoadingLocal) return;
+
+        // if the history array is empty, grab the previous value as the initial value
+        if (!history.length) {
+            const previous = getPrevious();
+            if (previous) history.push(internal.clone(previous));
+            historyPointer = 0;
+        }
+
+        // We're just going to store a copy of the whole object every time it changes.
+        const snapshot = internal.clone(obs$.get());
+
+        if (options?.limit) {
+            // limit means the number of undos
+            history = history.slice(Math.max(0, history.length - options.limit));
+        } else {
+            history = history.slice(0, historyPointer + 1);
+        }
+
+        // we add another history item, which is limit + 1 -- but it's the current one
+        history.push(snapshot);
+
+        // We're going to keep a pointer to the current history state.
+        // This way, we can undo to many previous states, and redo.
+        historyPointer = history.length - 1;
+
+        updateUndoRedo();
+    });
+
+    return {
+        undo() {
+            if (historyPointer > 0) {
+                historyPointer--;
+
+                const snapshot = internal.clone(history[historyPointer]);
+                restoringFromHistory = true;
+                obs$.set(snapshot);
+                restoringFromHistory = false;
+            } else {
+                console.warn('Already at the beginning of undo history');
+            }
+
+            updateUndoRedo();
+        },
+        redo() {
+            if (historyPointer < history.length - 1) {
+                historyPointer++;
+
+                const snapshot = internal.clone(history[historyPointer]);
+                restoringFromHistory = true;
+                obs$.set(snapshot);
+                restoringFromHistory = false;
+            } else {
+                console.warn('Already at the end of undo history');
+            }
+
+            updateUndoRedo();
+        },
+        undos$: undos$,
+        redos$: redos$,
+        getHistory: () => history,
+    };
+}

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,5 +1,6 @@
 import { beginBatch, endBatch } from '../src/batching';
 import { trackHistory } from '../src/history/trackHistory';
+import { undoRedo } from '../src/history/undoRedo';
 import { observable } from '../src/observable';
 
 function promiseTimeout(time?: number) {
@@ -90,5 +91,210 @@ describe('History', () => {
         const historyKeys = Object.keys(history);
 
         expect(history.get()[historyKeys[0]]).toEqual({ test: undefined });
+    });
+});
+
+describe('Undo/Redo', () => {
+    test('Undo/Redo', () => {
+        const obs = observable({ test: 'hi' });
+        const { undo, redo, undos$, redos$, getHistory } = undoRedo(obs);
+
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(0);
+
+        obs.set({ test: 'hello' });
+
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(0);
+
+        undo();
+        expect(obs.get()).toEqual({ test: 'hi' });
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(1);
+
+        redo();
+        expect(obs.get()).toEqual({ test: 'hello' });
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(0);
+
+        expect(getHistory()).toEqual([{ test: 'hi' }, { test: 'hello' }]);
+    });
+
+    test('Undo/Redo with multiple changes', () => {
+        const obs = observable({ test: 'hi', test2: 'a' });
+        const { undo, redo, undos$, redos$, getHistory } = undoRedo(obs);
+
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(0);
+
+        obs.assign({ test: 'hello', test2: 'b' });
+
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(0);
+
+        undo();
+        expect(obs.get()).toEqual({ test: 'hi', test2: 'a' });
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(1);
+
+        redo();
+        expect(obs.get()).toEqual({ test: 'hello', test2: 'b' });
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(0);
+
+        expect(getHistory()).toEqual([
+            { test: 'hi', test2: 'a' },
+            { test: 'hello', test2: 'b' },
+        ]);
+    });
+
+    test('Undo/Redo with batching', () => {
+        const obs = observable({ test: 'hi', test2: 'a' });
+        const { undo, redo, undos$, redos$, getHistory } = undoRedo(obs);
+
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(0);
+
+        beginBatch();
+        obs.assign({ test: 'hello' });
+        obs.assign({ test2: 'b' });
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(0);
+        endBatch();
+
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(0);
+
+        undo();
+        expect(obs.get()).toEqual({ test: 'hi', test2: 'a' });
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(1);
+
+        redo();
+        expect(obs.get()).toEqual({ test: 'hello', test2: 'b' });
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(0);
+
+        expect(getHistory()).toEqual([
+            { test: 'hi', test2: 'a' },
+            { test: 'hello', test2: 'b' },
+        ]);
+    });
+
+    test('Undo/Redo with multiple changes after undoing', () => {
+        const obs$ = observable({ test: 'hi', test2: 'a' });
+        const { undo, redo, undos$, redos$, getHistory } = undoRedo(obs$);
+
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(0);
+
+        obs$.test.set('hello');
+
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(0);
+        expect(obs$.test.get()).toBe('hello');
+        expect(obs$.get()).toEqual({ test: 'hello', test2: 'a' });
+
+        undo();
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(1);
+        expect(obs$.get()).toEqual({ test: 'hi', test2: 'a' });
+
+        // no batching, so it'll change twice
+        obs$.test2.set('b'); // from 'a'
+        obs$.test.set('world'); // from 'hi'
+
+        expect(undos$.get()).toBe(2); // should be 2 undos
+        expect(redos$.get()).toBe(0); // deleted the existing redo
+        expect(obs$.get()).toEqual({ test: 'world', test2: 'b' });
+
+        undo();
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(1);
+        expect(obs$.get()).toEqual({ test: 'hi', test2: 'b' });
+
+        undo();
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(2);
+        expect(obs$.get()).toEqual({ test: 'hi', test2: 'a' });
+
+        redo();
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(1);
+        expect(obs$.get()).toEqual({ test: 'hi', test2: 'b' });
+
+        expect(getHistory()).toEqual([
+            { test: 'hi', test2: 'a' },
+            { test: 'hi', test2: 'b' },
+            { test: 'world', test2: 'b' },
+        ]);
+    });
+
+    test('Undo/Redo with a limit on history length', () => {
+        const obs$ = observable({ test: 'hi', test2: 'a' });
+        const { undo, redo, undos$, redos$, getHistory } = undoRedo(obs$, { limit: 3 });
+
+        expect(undos$.get()).toBe(0);
+        expect(redos$.get()).toBe(0);
+
+        obs$.test.set('hello');
+
+        expect(undos$.get()).toBe(1);
+        expect(redos$.get()).toBe(0);
+        expect(obs$.test.get()).toBe('hello');
+        expect(obs$.get()).toEqual({ test: 'hello', test2: 'a' });
+
+        obs$.test2.set('b');
+
+        expect(undos$.get()).toBe(2);
+        expect(redos$.get()).toBe(0);
+        expect(obs$.get()).toEqual({ test: 'hello', test2: 'b' });
+
+        obs$.test.set('world');
+
+        expect(getHistory()).toEqual([
+            { test: 'hi', test2: 'a' },
+            { test: 'hello', test2: 'a' },
+            { test: 'hello', test2: 'b' },
+            { test: 'world', test2: 'b' },
+        ]);
+
+        expect(undos$.get()).toBe(3); // number of undos
+        expect(redos$.get()).toBe(0);
+        expect(obs$.get()).toEqual({ test: 'world', test2: 'b' });
+
+        obs$.test2.set('c');
+
+        expect(getHistory()).toEqual([
+            // { test: 'hi', test2: 'a' }, // truncated!
+            { test: 'hello', test2: 'a' },
+            { test: 'hello', test2: 'b' },
+            { test: 'world', test2: 'b' },
+            { test: 'world', test2: 'c' },
+        ]);
+        expect(undos$.get()).toBe(3); // number of undos
+        expect(redos$.get()).toBe(0);
+
+        obs$.test.set('terve'); // "hello" in finnish
+
+        expect(getHistory()).toEqual([
+            // { test: 'hi', test2: 'a' }, // truncated!
+            // { test: 'hello', test2: 'a' }, // truncated!
+            { test: 'hello', test2: 'b' },
+            { test: 'world', test2: 'b' },
+            { test: 'world', test2: 'c' },
+            { test: 'terve', test2: 'c' },
+        ]);
+
+        expect(undos$.get()).toBe(3); // number of undos
+        expect(redos$.get()).toBe(0);
+
+        undo();
+        undo();
+        redo();
+
+        expect(obs$.get()).toEqual({ test: 'world', test2: 'c' });
+        expect(undos$.get()).toBe(2);
+        expect(redos$.get()).toBe(1);
     });
 });


### PR DESCRIPTION
This adds an `undoRedo(obs$, { limit: number })` helper for observing changes to an observable and allowing for undo/redo capabilities.

Usage:

Use this function to add undo/redo functionality to an observable.

You can monitor how many undos or redos are available to enable/disable undo/redo
UI elements with undo$ and redo$.

If you undo and then make a change, it'll delete any redos and add the new change, which is how most undo/redo systems work.

 If you don't pass in a limit, it will keep all history. This means it can grow indefinitely.

 ```typescript
import { observable } from "@legendapp/state"
import { undoRedo } from "@legendapp/state/history"

 const obs$ = observable({ test: 'hi', test2: 'a' });
 const { undo, redo, undos$, redos$, getHistory } = undoRedo(obs$, { limit: 40 });
 obs$.test.set('hello');
 undo();
 redo();
 // observables for # of undos/redos available
 undos$.get();
 redos$.get();
 ```