### PR TITLE
WIP: allow hard deletes with synced subscribe

### DIFF
--- a/src/sync/syncTypes.ts
+++ b/src/sync/syncTypes.ts
@@ -62,6 +62,7 @@ export interface SyncedSetParams<T>
 export interface SyncedSubscribeParams<T = any> extends SyncedGetSetSubscribeBaseParams<T> {
     lastSync: number | undefined;
     update: UpdateFn<T>;
+    deleteFn: (id: string | number) => void;
     onError: (error: Error) => void;
 }
 


### PR DESCRIPTION
As noted in [this issue](https://github.com/LegendApp/legend-state/issues/328), the docs don't make indication that synced subscribes require use of soft-deletes.

I just started hacking this in, but I'm going to pause and wait to complete in case someone chimes in with a reason why synced-subscribes fundametally require soft deletion.