### PR TITLE
Add indexeddb persist options to handle db version changes

### DIFF
--- a/src/sync/syncTypes.ts
+++ b/src/sync/syncTypes.ts
@@ -111,6 +111,8 @@ export interface ObservablePersistIndexedDBPluginOptions {
     databaseName: string;
     version: number;
     tableNames: string[];
+    deleteTableNames?: string[];
+    onUpgradeNeeded?: (event: IDBVersionChangeEvent) => void;
 }
 export interface ObservablePersistAsyncStoragePluginOptions {
     AsyncStorage: AsyncStorageStatic;


### PR DESCRIPTION
- Add optional persist option to provide own onUpgradeNeeded handler. This gives full control over the objectstore and context of old and new version.
- Add optional persist option to give list of tables to delete.
