### PR TITLE
Fix persisting null with ObservablePersistMMKV

### DIFF
--- a/src/persist-plugins/mmkv.ts
+++ b/src/persist-plugins/mmkv.ts
@@ -85,7 +85,11 @@ export class ObservablePersistMMKV implements ObservablePersistPlugin {
         const v = this.data[table];
         if (v !== undefined) {
             try {
-                storage.set(table, safeStringify(v));
+                if (v !== null) {
+                    storage.set(table, safeStringify(v));
+                } else {
+                    storage.delete(table);
+                }
             } catch (err) {
                 console.error(err);
             }


### PR DESCRIPTION
This PR fixes persisting `null` values in observable when using `ObservablePersistMMKV`.

Consider this piece of code:

```ts
const obs = observable<string | null>("foo");

syncObservable(obs, {
  persist: {
    name: "obs",
    plugin: ObservablePersistMMKV
  },
});

obs.set(null);
```

This logs the following error:
```
[Error: Second argument ('value') has to be of type bool, number or string!]
```

and the old value is restored on next launch.

This happens because the persist plugin tries to call `storage.set(null)` while it's not supported by `react-native-mmkv`