### PR TITLE
fix: use `fieldId` prop for supase update and delete functions

### DIFF
--- a/src/sync-plugins/supabase.ts
+++ b/src/sync-plugins/supabase.ts
@@ -433,7 +433,9 @@ export function syncedSupabase<
     >({
         ...rest,
         mode: mode || 'merge',
-        list: list as any,
+        list: list as (
+            params: SyncedGetParams<SupabaseRowOf<Client, Collection, SchemaName>>,
+        ) => Promise<SupabaseRowOf<Client, Collection, SchemaName>[] | null>,
         create,
         update,
         delete: deleteFn,

--- a/src/sync-plugins/supabase.ts
+++ b/src/sync-plugins/supabase.ts
@@ -215,7 +215,7 @@ export function syncedSupabase<
         fieldUpdatedAt,
         fieldDeleted,
         realtime,
-        fieldId,
+        fieldId = 'id',
         changesSince,
         transform: transformParam,
         stringifyDates,
@@ -310,8 +310,7 @@ export function syncedSupabase<
                 ? wrapSupabaseFn(updateParam, 'update')
                 : async (input: SupabaseRowOf<Client, Collection, SchemaName>, params: SyncedSetParams<TRemote>) => {
                       const { onError } = params;
-                      const idField = props.fieldId || 'id';
-                      const res = await client.from(collection).update(input).eq(idField, input[idField]).select();
+                      const res = await client.from(collection).update(input).eq(fieldId, input[fieldId]).select();
                       const { data, error } = res;
                       if (data) {
                           const created = data[0];
@@ -339,8 +338,7 @@ export function syncedSupabase<
                       params: SyncedSetParams<TRemote>,
                   ) => {
                       const { onError } = params;
-                      const idField = props.fieldId || 'id';
-                      const res = await client.from(collection).delete().eq(idField, input[idField]).select();
+                      const res = await client.from(collection).delete().eq(fieldId, input[fieldId]).select();
                       const { data, error } = res;
                       if (data) {
                           const created = data[0];

--- a/src/sync-plugins/supabase.ts
+++ b/src/sync-plugins/supabase.ts
@@ -372,7 +372,7 @@ export function syncedSupabase<
                       (payload) => {
                           const { eventType, new: value, old } = payload;
                           if (eventType === 'INSERT' || eventType === 'UPDATE') {
-                              const cur = value$.peek()?.[value.id];
+                              const cur = value$.peek()?.[value[fieldId]];
                               let isOk = !fieldUpdatedAt;
                               let lastSync = undefined;
                               if (!isOk) {

--- a/src/sync-plugins/supabase.ts
+++ b/src/sync-plugins/supabase.ts
@@ -310,11 +310,8 @@ export function syncedSupabase<
                 ? wrapSupabaseFn(updateParam, 'update')
                 : async (input: SupabaseRowOf<Client, Collection, SchemaName>, params: SyncedSetParams<TRemote>) => {
                       const { onError } = params;
-                      const res = await client
-                          .from(collection)
-                          .update(input)
-                          .eq(props.fieldId || 'id', input.id)
-                          .select();
+                      const idField = props.fieldId || 'id';
+                      const res = await client.from(collection).update(input).eq(idField, input[idField]).select();
                       const { data, error } = res;
                       if (data) {
                           const created = data[0];
@@ -338,16 +335,12 @@ export function syncedSupabase<
               deleteParam
                 ? wrapSupabaseFn(deleteParam, 'delete')
                 : (async (
-                      input: { id: SupabaseRowOf<Client, Collection, SchemaName>['id'] },
+                      input: { [key: string]: SupabaseRowOf<Client, Collection, SchemaName>['id'] },
                       params: SyncedSetParams<TRemote>,
                   ) => {
                       const { onError } = params;
-                      const id = input.id;
-                      const res = await client
-                          .from(collection)
-                          .delete()
-                          .eq(props.fieldId || 'id', id)
-                          .select();
+                      const idField = props.fieldId || 'id';
+                      const res = await client.from(collection).delete().eq(idField, input[idField]).select();
                       const { data, error } = res;
                       if (data) {
                           const created = data[0];

--- a/src/sync-plugins/supabase.ts
+++ b/src/sync-plugins/supabase.ts
@@ -215,6 +215,7 @@ export function syncedSupabase<
         fieldUpdatedAt,
         fieldDeleted,
         realtime,
+        fieldId,
         changesSince,
         transform: transformParam,
         stringifyDates,
@@ -309,7 +310,11 @@ export function syncedSupabase<
                 ? wrapSupabaseFn(updateParam, 'update')
                 : async (input: SupabaseRowOf<Client, Collection, SchemaName>, params: SyncedSetParams<TRemote>) => {
                       const { onError } = params;
-                      const res = await client.from(collection).update(input).eq('id', input.id).select();
+                      const res = await client
+                          .from(collection)
+                          .update(input)
+                          .eq(props.fieldId || 'id', input.id)
+                          .select();
                       const { data, error } = res;
                       if (data) {
                           const created = data[0];
@@ -338,7 +343,11 @@ export function syncedSupabase<
                   ) => {
                       const { onError } = params;
                       const id = input.id;
-                      const res = await client.from(collection).delete().eq('id', id).select();
+                      const res = await client
+                          .from(collection)
+                          .delete()
+                          .eq(props.fieldId || 'id', id)
+                          .select();
                       const { data, error } = res;
                       if (data) {
                           const created = data[0];
@@ -433,6 +442,7 @@ export function syncedSupabase<
         fieldUpdatedAt,
         fieldDeleted,
         updatePartial: false,
+        fieldId,
         transform,
         generateId,
         waitFor: () => isEnabled$.get() && (waitFor ? computeSelector(waitFor) : true),


### PR DESCRIPTION
The supabase sync plugin is hard coded to reference the `id` column on update or delete. I updated it to respect the `fieldId` property and falls back to `id` when not explicitly set.

Also had to assert the list function for it to pass tests and build, let me know if that should be removed.