### PR TITLE
Enhance observe and useObservable with Multiple Observables Support

### DIFF
--- a/src/react/useObserve.ts
+++ b/src/react/useObserve.ts
@@ -52,14 +52,19 @@ export function useObserve<T>(
     ref.current.selector = deps
         ? () => {
               depsObs$?.get();
-              return computeSelector(selector);
+              return Array.isArray(selector) ? selector.map((sel) => computeSelector(sel)) : computeSelector(selector);
           }
         : selector;
     ref.current.reaction = reaction;
 
     if (!ref.current.dispose) {
         ref.current.dispose = observe<T>(
-            ((e: ObserveEventCallback<T>) => computeSelector(ref.current.selector, undefined, e)) as any,
+            ((e: ObserveEventCallback<T>) => {
+                if (Array.isArray(ref.current.selector)) {
+                    return ref.current.selector.map((sel) => computeSelector(sel, undefined, e));
+                }
+                return computeSelector(ref.current.selector, undefined, e);
+            }) as any,
             (e) => ref.current.reaction?.(e),
             options,
         );

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -1644,12 +1644,12 @@ describe('useObservable', () => {
         let lastValue:
             | undefined
             | {
-                  hotspot: {
-                      position: {
-                          x: number;
-                      };
-                  };
-              }[] = undefined;
+                hotspot: {
+                    position: {
+                        x: number;
+                    };
+                };
+            }[] = undefined;
         const Test = observer(function Test() {
             const c$ = useComputed(() => {
                 return o$;
@@ -1735,6 +1735,32 @@ describe('useObservable', () => {
 
         expect(num).toEqual(2);
         expect(value).toEqual(1 + '_' + originalRand);
+    });
+    test('Observe handle multiples observables', () => {
+        const obs1 = observable({ type: 'multiplication' });
+        const obs2 = observable({ number1: 1, number2: 2 });
+        let observableResult;
+        function Test() {
+            useObserve([obs1, obs2], () => {
+                observableResult =
+                    obs1.type.peek() === 'multiplication'
+                        ? obs2.number1.peek() * obs2.number2.peek()
+                        : obs2.number1.peek() + obs2.number2.peek();
+            });
+            return createElement('div', undefined);
+        }
+        render(createElement(Test));
+
+        expect(observableResult).toBe(2);
+        act(() => {
+            obs1.set({ type: 'addition' });
+        });
+        expect(observableResult).toBe(3);
+
+        act(() => {
+            obs2.set({ number1: 3, number2: 4 });
+        });
+        expect(observableResult).toBe(7);
     });
 });
 describe('useObservableState', () => {
@@ -1930,7 +1956,7 @@ describe('react validation', () => {
 describe('tracing', () => {
     beforeEach(() => {
         // Mock console.log before each test
-        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => { });
     });
 
     afterEach(() => {

--- a/tests/tests.test.ts
+++ b/tests/tests.test.ts
@@ -3229,23 +3229,21 @@ describe('Observe', () => {
         expect(lastLength).toEqual(5);
     });
     test('Observe handle multiples observables', () => {
-        test('Observe handle multiples observables', () => {
-            const obs1 = observable({ type: 'multiplication' });
-            const obs2 = observable({ number1: 1, number2: 2 });
-            let observableResult;
-            observe([obs1, obs2], () => {
-                observableResult =
-                    obs1.type.peek() === 'multiplication'
-                        ? obs2.number1.peek() * obs2.number2.peek()
-                        : obs2.number1.peek() + obs2.number2.peek();
-            });
-            expect(observableResult).toBe(2);
-            obs1.set({ type: 'addition' });
-            expect(observableResult).toBe(3);
-
-            obs2.set({ number1: 3, number2: 4 });
-            expect(observableResult).toBe(7);
+        const obs1 = observable({ type: 'multiplication' });
+        const obs2 = observable({ number1: 1, number2: 2 });
+        let observableResult;
+        observe([obs1, obs2], () => {
+            observableResult =
+                obs1.type.peek() === 'multiplication'
+                    ? obs2.number1.peek() * obs2.number2.peek()
+                    : obs2.number1.peek() + obs2.number2.peek();
         });
+        expect(observableResult).toBe(2);
+        obs1.set({ type: 'addition' });
+        expect(observableResult).toBe(3);
+
+        obs2.set({ number1: 3, number2: 4 });
+        expect(observableResult).toBe(7);
     });
 });
 describe('Error detection', () => {

--- a/tests/tests.test.ts
+++ b/tests/tests.test.ts
@@ -3228,6 +3228,25 @@ describe('Observe', () => {
         state$.arr.push(10);
         expect(lastLength).toEqual(5);
     });
+    test('Observe handle multiples observables', () => {
+        test('Observe handle multiples observables', () => {
+            const obs1 = observable({ type: 'multiplication' });
+            const obs2 = observable({ number1: 1, number2: 2 });
+            let observableResult;
+            observe([obs1, obs2], () => {
+                observableResult =
+                    obs1.type.peek() === 'multiplication'
+                        ? obs2.number1.peek() * obs2.number2.peek()
+                        : obs2.number1.peek() + obs2.number2.peek();
+            });
+            expect(observableResult).toBe(2);
+            obs1.set({ type: 'addition' });
+            expect(observableResult).toBe(3);
+
+            obs2.set({ number1: 3, number2: 4 });
+            expect(observableResult).toBe(7);
+        });
+    });
 });
 describe('Error detection', () => {
     test('Circular objects in set', () => {


### PR DESCRIPTION
I believe this could be a valuable feature, similar to how useEffect works in React. In my experience, when using observable and useObservable, there are times when I want to listen to multiple observables and react to changes in one or all of them (or even in another). Currently, the only workaround is to call useObservable multiple times and duplicate the logic within each instance.

It would be much more efficient and elegant to allow passing an array of observables, similar to the dependency array in useEffect. This way, we could listen to multiple changes and respond when any of these observables update. Here’s an example to illustrate the idea:

It is particular
```js
const obs1 = observable({ type: 'multiplication' });
const obs2 = observable({ number1: 1, number2: 2 });
let observableResult;
observe([obs1, obs2], () => {
    observableResult =
        obs1.type.peek() === 'multiplication'
            ? obs2.number1.peek() * obs2.number2.peek()
            : obs2.number1.peek() + obs2.number2.peek();

   console.log(obsrvableResult)
});
// Output: 2

obs1.set({ type: 'addition' });
// Output: 3

obs2.set({ number1: 3, number2: 4 });
// Output: 7
```