### PR TITLE
fix: add JSX type import to resolve TypeScript compilation error

### DIFF
--- a/src/react-web/$React.tsx
+++ b/src/react-web/$React.tsx
@@ -1,6 +1,6 @@
 import { isEmpty, isFunction } from '@legendapp/state';
 import { reactive, BindKeys, FCReactiveObject } from '@legendapp/state/react';
-import { createElement, FC, forwardRef } from 'react';
+import { createElement, FC, forwardRef, type JSX } from 'react';
 
 type IReactive = FCReactiveObject<JSX.IntrinsicElements>;
 


### PR DESCRIPTION
Solve the problem of `$React` not having types in the IDE