### PR TITLE
fix: ArrayLoopers like forEach should not autocreate nodes

### DIFF
--- a/src/ObservableObject.ts
+++ b/src/ObservableObject.ts
@@ -489,7 +489,7 @@ const proxyHandler: ProxyHandler<any> = {
 
         if (isNullOrUndefined(value) && vProp === undefined && (ArrayModifiers.has(p) || ArrayLoopers.has(p))) {
             value = [];
-            setNodeValue(node, value);
+            if (ArrayModifiers.has(p)) setNodeValue(node, value);
             vProp = value[p];
         }
 

--- a/tests/tests.test.ts
+++ b/tests/tests.test.ts
@@ -1481,6 +1481,14 @@ describe('Array', () => {
         obs.arr.forEach((a) => arr.push(isObservable(a)));
         expect(arr).toEqual([true]);
     });
+    test('Array forEach does not autocreate node', () => {
+        interface Data {
+            arr?: Array<{ text: string }>;
+        }
+        const obs = observable<Data>({});
+        obs.arr.forEach(() => null);
+        expect(obs.arr.peek()).toEqual(undefined);
+    });
     test('Array splice does not call child listeners when not affected', () => {
         const obs = observable({
             arr: [


### PR DESCRIPTION
Calls with ArrayLoopers like .forEach() on an undefined node should not create an empty array. This can lead to unecessary execution of observe function listeners after a major parent node get's deleted.