### PR TITLE
Feature/persist watermelondb

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "@evilmartians/lefthook": "^1.6.13",
         "@happy-dom/global-registrator": "^14.12.0",
         "@jest/globals": "^29.7.0",
+        "@nozbe/watermelondb": "^0.28.0",
         "@react-native-async-storage/async-storage": "^1.23.1",
         "@release-it/conventional-changelog": "^8.0.1",
         "@supabase/supabase-js": "^2.43.4",

--- a/src/persist-plugins/watermelondb.ts
+++ b/src/persist-plugins/watermelondb.ts
@@ -1,74 +1,70 @@
-import { applyChanges } from '@legendapp/state'
+import { applyChanges } from '@legendapp/state';
 
-import type {
-    ObservablePersistPlugin,
-    PersistMetadata,
-    PersistOptions,
-} from '@legendapp/state/sync'
+import type { ObservablePersistPlugin, PersistMetadata, PersistOptions } from '@legendapp/state/sync';
 import type { Change } from '@legendapp/state';
-import type LocalStorage from '@nozbe/watermelondb/Database/LocalStorage'
+import type LocalStorage from '@nozbe/watermelondb/Database/LocalStorage';
 
-const MetadataSuffix = '__m'
+const MetadataSuffix = '__m';
 
 class ObservablePersistWatermelonDB implements ObservablePersistPlugin {
-    private readonly storage: LocalStorage
-    private data: Record<string, unknown> = {}
+    private readonly storage: LocalStorage;
+    private data: Record<string, unknown> = {};
 
     constructor(storage: LocalStorage) {
         if (!storage) {
             console.error(
-                '[legend-state] ObservablePersistWatermelonDB failed to initialize. You need to pass the WatermelonDB localStorage instance.'
-            )
+                '[legend-state] ObservablePersistWatermelonDB failed to initialize. You need to pass the WatermelonDB localStorage instance.',
+            );
         }
 
-        this.storage = storage
+        this.storage = storage;
     }
 
     getTable<T = any>(table: string, init: any): T {
-        if (!this.storage) return undefined
+        if (!this.storage) return undefined;
 
         if (this.data[table] === undefined) {
             try {
                 this.storage._getSync(table, (val) => {
-                    if (val !== undefined) this.data[table] = val
-                })
+                    if (val !== undefined) this.data[table] = val;
+                });
             } catch (e) {
-                console.error('[legend-state] ObservablePersistWatermelonDB parse failed', table, e)
+                console.error('[legend-state] ObservablePersistWatermelonDB parse failed', table, e);
             }
         }
 
-        return this.data[table]
+        return this.data[table];
     }
 
     deleteTable(table: string): Promise<void> | void {
-        if (!this.storage) return undefined
+        if (!this.storage) return undefined;
 
-        delete this.data[table]
-        return this.storage.remove(table)
+        delete this.data[table];
+        return this.storage.remove(table);
     }
 
     set(table: string, changes: Change[]): Promise<void> | void {
-        const current = this.data[table] ?? {}
-        const updated = applyChanges(current, changes)
-        this.data[table] = updated
+        const current = this.data[table] ?? {};
+        const updated = applyChanges(current, changes);
+        this.data[table] = updated;
 
-        return this.storage.set(table, updated)
+        return this.storage.set(table, updated);
     }
 
     getMetadata(table: string, _config: PersistOptions): PersistMetadata {
-        return this.getTable(table + MetadataSuffix, {})
+        return this.getTable(table + MetadataSuffix, {});
     }
 
     setMetadata(table: string, metadata: PersistMetadata): Promise<void> | void {
-        const key = table + MetadataSuffix
-        this.data[key] = metadata
-        return this.storage.set(key, metadata)
+        const key = table + MetadataSuffix;
+        this.data[key] = metadata;
+        return this.storage.set(key, metadata);
     }
 
     deleteMetadata(table: string): Promise<void> | void {
-        const key = table + MetadataSuffix
-        delete this.data[key]
-        return this.storage.remove(key)
+        const key = table + MetadataSuffix;
+        delete this.data[key];
+        return this.storage.remove(key);
     }
 }
 
@@ -91,5 +87,5 @@ class ObservablePersistWatermelonDB implements ObservablePersistPlugin {
  * ```
  */
 export function observablePersistWatermelonDB(localStorage: LocalStorage) {
-    return new ObservablePersistWatermelonDB(localStorage)
+    return new ObservablePersistWatermelonDB(localStorage);
 }

--- a/src/persist-plugins/watermelondb.ts
+++ b/src/persist-plugins/watermelondb.ts
@@ -1,0 +1,95 @@
+import { applyChanges } from '@legendapp/state'
+
+import type {
+    ObservablePersistPlugin,
+    PersistMetadata,
+    PersistOptions,
+} from '@legendapp/state/sync'
+import type { Change } from '@legendapp/state';
+import type LocalStorage from '@nozbe/watermelondb/Database/LocalStorage'
+
+const MetadataSuffix = '__m'
+
+class ObservablePersistWatermelonDB implements ObservablePersistPlugin {
+    private readonly storage: LocalStorage
+    private data: Record<string, unknown> = {}
+
+    constructor(storage: LocalStorage) {
+        if (!storage) {
+            console.error(
+                '[legend-state] ObservablePersistWatermelonDB failed to initialize. You need to pass the WatermelonDB localStorage instance.'
+            )
+        }
+
+        this.storage = storage
+    }
+
+    getTable<T = any>(table: string, init: any): T {
+        if (!this.storage) return undefined
+
+        if (this.data[table] === undefined) {
+            try {
+                this.storage._getSync(table, (val) => {
+                    if (val !== undefined) this.data[table] = val
+                })
+            } catch (e) {
+                console.error('[legend-state] ObservablePersistWatermelonDB parse failed', table, e)
+            }
+        }
+
+        return this.data[table]
+    }
+
+    deleteTable(table: string): Promise<void> | void {
+        if (!this.storage) return undefined
+
+        delete this.data[table]
+        return this.storage.remove(table)
+    }
+
+    set(table: string, changes: Change[]): Promise<void> | void {
+        const current = this.data[table] ?? {}
+        const updated = applyChanges(current, changes)
+        this.data[table] = updated
+
+        return this.storage.set(table, updated)
+    }
+
+    getMetadata(table: string, _config: PersistOptions): PersistMetadata {
+        return this.getTable(table + MetadataSuffix, {})
+    }
+
+    setMetadata(table: string, metadata: PersistMetadata): Promise<void> | void {
+        const key = table + MetadataSuffix
+        this.data[key] = metadata
+        return this.storage.set(key, metadata)
+    }
+
+    deleteMetadata(table: string): Promise<void> | void {
+        const key = table + MetadataSuffix
+        delete this.data[key]
+        return this.storage.remove(key)
+    }
+}
+
+/**
+ * Usage:
+ * ```ts
+ * import { syncObservable } from '@legendapp/state/sync'
+ * import { observable } from '@legendapp/state'
+ * import { observablePersistWatermelonDB } from '@legendapp/state/persist-plugins/watermelondb'
+ * import { database } from '@/lib/db' // Watermelon Database
+ *
+ * const settings$ = observable(true)
+ *
+ * syncObservable(settings$, {
+ *   persist: {
+ *     name: 'settings',
+ *     plugin: observablePersistWatermelonDB(database.localStorage),
+ *   },
+ * })
+ * ```
+ */
+export function observablePersistWatermelonDB(localStorage: LocalStorage) {
+    return new ObservablePersistWatermelonDB(localStorage)
+}


### PR DESCRIPTION
This PR adds a first-class WatermelonDB LocalStorage persist plugin to @legendapp/state/sync. It enables fast, reliable persistence for React Native / Expo apps that use @nozbe/watermelondb, with synchronous reads.

	•	Zero new runtime dependencies
	•	No breaking changes
	
Changes

	•	src/persist-plugins/watermelondb.ts (new)
	
Usage
```ts
import { observable } from '@legendapp/state'
import { syncObservable } from '@legendapp/state/sync'
import { observablePersistWatermelonDB } from '@legendapp/state/persist-plugins/watermelondb'
import { database } from '@/lib/db' // Watermelon Database

const settings$ = observable(true)

syncObservable(settings$, {
  persist: {
    name: 'settings',
    plugin: observablePersistWatermelonDB(database.localStorage),
  },
})
```