### PR TITLE
Fix: reset synced observable

### DIFF
--- a/src/sync/syncObservable.ts
+++ b/src/sync/syncObservable.ts
@@ -969,6 +969,10 @@ export function syncObservable<T>(
         observableSyncConfiguration,
         removeNullUndefined(syncOptions || {}),
     );
+
+    // Store the original initial value to preserve it for reset functionality
+    const originalInitial = clone(syncOptions.initial);
+
     const localState: LocalState = {};
     let sync: () => Promise<void>;
 
@@ -1366,7 +1370,7 @@ export function syncObservable<T>(
         unsubscribe = undefined;
         const promise = syncStateValue.resetPersistence();
         onChangeRemote(() => {
-            obs$.set(syncOptions.initial ?? undefined);
+            obs$.set(clone(originalInitial) ?? undefined);
         });
         syncState$.isLoaded.set(false);
         syncStateValue.isPersistEnabled = wasPersistEnabled;

--- a/src/sync/syncObservable.ts
+++ b/src/sync/syncObservable.ts
@@ -1377,6 +1377,13 @@ export function syncObservable<T>(
         syncStateValue.isSyncEnabled = wasSyncEnabled;
         node.dirtyFn = sync;
         await promise;
+
+        // For observables without remote data loading (no get function), set isLoaded back to true
+        // since there's no remote data to load. This matches the initial loading logic.
+        const hasRemoteLoad = !!syncOptions.get;
+        if (!hasRemoteLoad) {
+            syncState$.isLoaded.set(true);
+        }
     };
 
     // Wait for this node and all parent nodes up the hierarchy to be loaded


### PR DESCRIPTION
This PR was developed when I started having problems trying to reset a `syncedCrud` observable with `syncState.reset()`.

- fix `syncState.reset()` not updating observable's value when the initial value of a synced observable is an empty object
- fix `syncState.reset()` not updating observable's value when called multiple times (I had this issue in an Expo to-dos test page, where I set up a synced observable and added one to-do, then reset, then added one to-do again, then reset again. On the second reset, the observable's value didn't update)
- fix `syncState.isLoaded` not being set correctly when resetting a synced observable that didn't have the `get` property (e.g. `syncedCrud` with `list` property)
- add tests for the use cases fixed in this PR