### PR TITLE
fix: ObservableHint.opaque infer original type

### DIFF
--- a/src/observableTypes.ts
+++ b/src/observableTypes.ts
@@ -1,6 +1,6 @@
-import type { GetOptions, ListenerFn, TrackingType } from './observableInterfaces';
+import type { GetOptions, ListenerFn, OpaqueObject, TrackingType } from './observableInterfaces';
 
-type Primitive = string | number | boolean | symbol | bigint | undefined | null | Date;
+type Primitive = string | number | boolean | symbol | bigint | undefined | null | Date | OpaqueObject<unknown>;
 type ArrayOverrideFnNames =
     | 'find'
     | 'findIndex'
@@ -17,7 +17,7 @@ type RemoveIndex<T> = {
     [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K];
 };
 
-type BuiltIns = String | Boolean | Number | Date | Error | RegExp | Array<any> | Function | Promise<any>;
+type BuiltIns = String | Boolean | Number | Date | Error | RegExp | Array<any> | Function | Promise<any> | OpaqueObject<any>;
 
 type IsUserDefinedObject<T> =
     // Only objects that are not function or arrays or instances of BuiltIns.
@@ -38,7 +38,9 @@ export type RemoveObservables<T> =
                 ? RemoveObservables<TRet> & T
                 : T extends (key: infer TKey extends string | number) => infer TRet
                   ? Record<TKey, RemoveObservables<TRet>> & T
-                  : T;
+                  : T extends OpaqueObject<infer TObj>
+                    ? TObj
+                    : T;
 
 interface ObservableArray<T, U>
     extends ObservablePrimitive<T>,

--- a/tests/tests.test.ts
+++ b/tests/tests.test.ts
@@ -8,11 +8,12 @@ import { clone, getNodeValue, isEvent, isObservable, optimized, symbolGetNode } 
 import { setAtPath } from '../src/helpers';
 import { linked } from '../src/linked';
 import { observable, observablePrimitive } from '../src/observable';
-import { NodeInfo } from '../src/observableInterfaces';
+import { NodeInfo, OpaqueObject } from '../src/observableInterfaces';
 import { observe } from '../src/observe';
 import { syncState } from '../src/syncState';
 import { when, whenReady } from '../src/when';
 import { expectChangeHandler, promiseTimeout } from './testglobals';
+import { ObservableHint } from '../src/ObservableHint';
 
 enable$GetSet();
 enable_PeekAssign();
@@ -1043,6 +1044,20 @@ describe('Primitives', () => {
         expect(obs.val.toString()).toBe('10');
         expect(obs.val.valueOf()).toBe(10);
     });
+    test('opaque object should be handled like primitives', () => {
+        class BigNumber {
+            readonly c: number[] | null = null;
+            readonly e: number | null = null;
+            readonly s: number | null = null;
+        }
+        const obs = observable<{ val: OpaqueObject<BigNumber> | null }>({
+            val: ObservableHint.opaque(new BigNumber())
+        });
+
+        const val /* infered: ObservablePrimitive<OpaqueObject<BigNumber> | null> */ = obs.val;
+        const raw /* infered: BigNumber | null */ = val.get();
+        expect(raw?.c).toBeNull();
+    })
 });
 describe('Array', () => {
     test('Basic array', () => {


### PR DESCRIPTION
Opaque object should be handled like primitives for typings. Fixes #555