### PR TITLE
fix: make has-trap more resilient

### DIFF
--- a/src/ObservableObject.ts
+++ b/src/ObservableObject.ts
@@ -632,7 +632,7 @@ const proxyHandler: ProxyHandler<any> = {
     },
     has(node: NodeInfo, prop: string) {
         const value = getNodeValue(node);
-        return Reflect.has(value, prop);
+        return value !== null && typeof value === 'object' && Reflect.has(value, prop);
     },
     apply(target, thisArg, argArray) {
         // If it's a function call it as a function


### PR DESCRIPTION
In unit tests without .peek() or .get(), we encountered many exceptions due to the behavior of vitest and chai when iterating over objects for equality checks and error printing. Making this more resilient without throwing exceptions seems like a useful improvement for me.