### PR TITLE
fix: Object.keys on object with non-configurable props should not fail

### DIFF
--- a/src/ObservableObject.ts
+++ b/src/ObservableObject.ts
@@ -596,7 +596,7 @@ const proxyHandler: ProxyHandler<any> = {
             return { configurable: false, enumerable: false };
         }
         const value = getNodeValue(node);
-        return isPrimitive(value) ? undefined : Reflect.getOwnPropertyDescriptor(value, prop);
+        return isPrimitive(value) ? undefined : { ...Reflect.getOwnPropertyDescriptor(value, prop), configurable: true };
     },
     set(node: NodeInfo, prop: string, value: any) {
         // If this assignment comes from within an observable function it's allowed

--- a/src/ObservableObject.ts
+++ b/src/ObservableObject.ts
@@ -596,7 +596,13 @@ const proxyHandler: ProxyHandler<any> = {
             return { configurable: false, enumerable: false };
         }
         const value = getNodeValue(node);
-        return isPrimitive(value) ? undefined : { ...Reflect.getOwnPropertyDescriptor(value, prop), configurable: true };
+
+        if (isPrimitive(value)) {
+            return undefined;
+        }
+
+        const descriptor = Reflect.getOwnPropertyDescriptor(value, prop);
+        return descriptor ? { ...descriptor, configurable: true } : undefined;
     },
     set(node: NodeInfo, prop: string, value: any) {
         // If this assignment comes from within an observable function it's allowed

--- a/tests/tests.test.ts
+++ b/tests/tests.test.ts
@@ -3817,4 +3817,25 @@ describe('Misc', () => {
         expect(Object.keys(obs$.get())).toEqual([]);
         expect(Object.keys(obs$)).toEqual([]);
     });
+    test('Object.keys on primitive should be undefined', () => {
+        const obs$ = observable({ value: 1 });
+
+        expect(Object.keys(obs$.value.get())).toEqual([]);
+        expect(Object.keys(obs$.value)).toEqual([]);
+
+        const descriptProxy = Object.getOwnPropertyDescriptor(obs$.value, 'missing');
+
+        expect(descriptProxy).toEqual(undefined);
+    });
+
+    test('Object.getOwnPropertyDescriptor with invalid prop should be undefined', () => {
+        const value = {};
+        const proxy = observable(value);
+
+        const descriptProxy = Object.getOwnPropertyDescriptor(proxy, 'missing');
+        const descriptValue = Object.getOwnPropertyDescriptor(value, 'missing');
+
+        expect(descriptProxy).toEqual(undefined);
+        expect(descriptValue).toEqual(undefined);
+    });
 });

--- a/tests/tests.test.ts
+++ b/tests/tests.test.ts
@@ -3805,4 +3805,16 @@ describe('Misc', () => {
 
         expect(changed).toEqual(false);
     });
+    test('Object.keys on object with non-configurable props should not fail', () => {
+        const target = {};
+        const obs$ = observable(target);
+
+        expect(Object.keys(obs$.get())).toEqual([]);
+        expect(Object.keys(obs$)).toEqual([]);
+
+        Object.defineProperty(target, 'a', { writable: true, enumerable: false, configurable: false });
+
+        expect(Object.keys(obs$.get())).toEqual([]);
+        expect(Object.keys(obs$)).toEqual([]);
+    });
 });


### PR DESCRIPTION
Currently it fails with "'getOwnPropertyDescriptor' on proxy: trap reported non-configurability for property 'a' which is either non-existent or configurable in the proxy target"

The reason for that is that the proxy target is the node and not the actual data. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor#invariants.