### PR TITLE
fix: ObservableHint.opaque infer original type

### DIFF
--- a/src/observableTypes.ts
+++ b/src/observableTypes.ts
@@ -24,22 +24,22 @@ type IsUserDefinedObject<T> =
     T extends Function | BuiltIns | any[] ? false : T extends object ? true : false;
 
 export type RemoveObservables<T> =
-    T extends ImmutableObservableBase<infer t>
+    T extends OpaqueObject<infer t>
         ? t
-        : T extends ImmutableObservableBase<infer t>[]
-          ? t[]
-          : IsUserDefinedObject<T> extends true
-            ? {
-                  [K in keyof T]: RemoveObservables<T[K]>;
-              }
-            : T extends ImmutableObservableBase<infer TObs>
-              ? TObs
-              : T extends () => infer TRet
-                ? RemoveObservables<TRet> & T
-                : T extends (key: infer TKey extends string | number) => infer TRet
-                  ? Record<TKey, RemoveObservables<TRet>> & T
-                  : T extends OpaqueObject<infer TObj>
-                    ? TObj
+        : T extends ImmutableObservableBase<infer t>
+          ? t
+          : T extends ImmutableObservableBase<infer t>[]
+            ? t[]
+            : IsUserDefinedObject<T> extends true
+              ? {
+                    [K in keyof T]: RemoveObservables<T[K]>;
+                }
+              : T extends ImmutableObservableBase<infer TObs>
+                ? TObs
+                : T extends () => infer TRet
+                  ? RemoveObservables<TRet> & T
+                  : T extends (key: infer TKey extends string | number) => infer TRet
+                    ? Record<TKey, RemoveObservables<TRet>> & T
                     : T;
 
 interface ObservableArray<T, U>


### PR DESCRIPTION
Fixes #555 again. Modified the previous variant - reverted by https://github.com/LegendApp/legend-state/commit/8bdf0f7320968a9c3853c3b675464c9e36ceac3b

Please let me know if it breaks something again and what exactly, so I can think about it.