### PR TITLE
fix(types): fix supabase views row types

### DIFF
--- a/src/sync-plugins/supabase.ts
+++ b/src/sync-plugins/supabase.ts
@@ -63,7 +63,7 @@ export type SupabaseRowOf<
     Client extends SupabaseClient,
     Collection extends SupabaseCollectionOf<Client, SchemaName>,
     SchemaName extends SchemaNameOf<Client>,
-> = SupabaseTableOf<Client, SchemaName>[Collection]['Row'];
+> = SupabaseTableOf<Client, SchemaName>[Collection]['Row'] & SupabaseViewOf<Client, SchemaName>[Collection]['Row'];
 
 export type SyncedSupabaseConfig<TRemote extends { id: string | number }, TLocal> = Omit<
     SyncedCrudPropsBase<TRemote, TLocal>,
@@ -125,7 +125,7 @@ interface SyncedSupabasePropsWithSelect<
     select: (
         query: PostgrestQueryBuilder<
             SupabaseSchemaOf<Client>,
-            SupabaseTableOf<Client, SchemaName>[Collection],
+            SupabaseTableOf<Client, SchemaName>[Collection] & SupabaseViewOf<Client, SchemaName>[Collection],
             Collection
         >,
     ) => PostgrestFilterBuilder<SupabaseSchemaOf<Client>, TRemote, TRemote[], Collection, []>;


### PR DESCRIPTION
Really appreciate your work

This PR extends the TypeScript type definitions in @legendapp/state to include Supabase View Rows and CRUD method parameters (create, update, list, etc.).

The recently merged PR [#523](https://github.com/LegendApp/legend-state/pull/523)
 addressed part of the issue — specifically enabling views to be shown in collections — but did not include proper type definitions for view rows or CRUD operation arguments.

This PR completes that missing piece by enhancing the typings for a more robust and type-safe developer experience when working with Supabase-backed entities.