### PR TITLE
fix(crud): use deepEqual for object change detection

### DIFF
--- a/src/sync-plugins/crud.ts
+++ b/src/sync-plugins/crud.ts
@@ -605,7 +605,7 @@ export function syncedCrud<TRemote extends object, TLocal = TRemote, TAsOption e
                                       // value is already the new value, can ignore
                                       (saved as any)[key] === c ||
                                       // user has changed local value
-                                      (key !== fieldId && i !== undefined && i !== c)
+                                      (key !== fieldId && i !== undefined && !deepEqual(i, c))
                                   ) {
                                       delete (saved as any)[key];
                                   }

--- a/src/sync/syncHelpers.ts
+++ b/src/sync/syncHelpers.ts
@@ -39,6 +39,15 @@ export function deepEqual<T extends Record<string, any> = any>(
 ): boolean {
     if (a === b) return true;
     if (isNullOrUndefined(a) !== isNullOrUndefined(b)) return false;
+
+    if (Array.isArray(a) && Array.isArray(b)) {
+        if (a.length !== b.length) return false;
+        for (let i = 0; i < a.length; i++) {
+            if (!deepEqual(a[i], b[i], ignoreFields, nullVsUndefined)) return false;
+        }
+        return true;
+    }
+
     if (!isObject(a) || !isObject(b)) return a === b;
 
     if (nullVsUndefined) {

--- a/tests/crud.test.ts
+++ b/tests/crud.test.ts
@@ -2770,7 +2770,7 @@ describe('onSaved', () => {
         });
     });
 
-    test('onSaved gets correct value as object', async () => {
+    test('onSaved gets correct value as object with deep nested object containing array', async () => {
         let saved = undefined;
         const obs = observable(
             syncedCrud({
@@ -2781,7 +2781,17 @@ describe('onSaved', () => {
                 },
                 generateId: () => 'id1',
                 onSaved(params) {
-                    params.saved = { ...params.saved, parent: { child: { baby: 'hello baby override' } } };
+                    params.saved = {
+                        ...params.saved,
+                        parent: {
+                            child: { baby: 'hello baby override' },
+                        },
+                        list: [
+                            { parent: { child: { baby: 'hello list baby 1' } } },
+                            { parent: { child: { baby: 'hello list baby 2 modified' } } },
+                            { parent: { child: { baby: 'hello list baby 3' } } },
+                        ],
+                    };
                     saved = params.saved;
                     return params.saved;
                 },
@@ -2790,19 +2800,42 @@ describe('onSaved', () => {
 
         await promiseTimeout(1);
 
-        obs.id1.set({ test: 'hello', id: undefined as unknown as string, parent: { child: { baby: 'hello baby' } } });
+        obs.id1.set({
+            test: 'hello',
+            id: undefined as unknown as string,
+            parent: { child: { baby: 'hello baby' } },
+            list: [
+                { parent: { child: { baby: 'hello list baby 1' } } },
+                { parent: { child: { baby: 'hello list baby 2' } } },
+                { parent: { child: { baby: 'hello list baby 3' } } },
+            ],
+        });
 
         await promiseTimeout(1);
 
         expect(saved).toEqual({
             id: 'id1',
             test: 'hello',
-            parent: { child: { baby: 'hello baby override' } },
+            parent: {
+                child: { baby: 'hello baby override' },
+            },
+            list: [
+                { parent: { child: { baby: 'hello list baby 1' } } },
+                { parent: { child: { baby: 'hello list baby 2 modified' } } },
+                { parent: { child: { baby: 'hello list baby 3' } } },
+            ],
         });
         expect(obs.id1.peek()).toEqual({
             id: 'id1',
             test: 'hello',
-            parent: { child: { baby: 'hello baby override' } },
+            parent: {
+                child: { baby: 'hello baby override' },
+            },
+            list: [
+                { parent: { child: { baby: 'hello list baby 1' } } },
+                { parent: { child: { baby: 'hello list baby 2 modified' } } },
+                { parent: { child: { baby: 'hello list baby 3' } } },
+            ],
         });
     });
 });

--- a/tests/crud.test.ts
+++ b/tests/crud.test.ts
@@ -2769,6 +2769,42 @@ describe('onSaved', () => {
             updatedAt: 12,
         });
     });
+
+    test('onSaved gets correct value as object', async () => {
+        let saved = undefined;
+        const obs = observable(
+            syncedCrud({
+                as: 'object',
+                fieldUpdatedAt: 'updatedAt',
+                create: async (input: BasicValue) => {
+                    return input;
+                },
+                generateId: () => 'id1',
+                onSaved(params) {
+                    params.saved = { ...params.saved, parent: { child: { baby: 'hello baby override' } } };
+                    saved = params.saved;
+                    return params.saved;
+                },
+            }),
+        );
+
+        await promiseTimeout(1);
+
+        obs.id1.set({ test: 'hello', id: undefined as unknown as string, parent: { child: { baby: 'hello baby' } } });
+
+        await promiseTimeout(1);
+
+        expect(saved).toEqual({
+            id: 'id1',
+            test: 'hello',
+            parent: { child: { baby: 'hello baby override' } },
+        });
+        expect(obs.id1.peek()).toEqual({
+            id: 'id1',
+            test: 'hello',
+            parent: { child: { baby: 'hello baby override' } },
+        });
+    });
 });
 describe('Order of get/create', () => {
     test('create with no get', async () => {

--- a/tests/testglobals.ts
+++ b/tests/testglobals.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
-import { ObservablePersistLocalStorageBase } from '../src/persist-plugins/local-storage';
 import type { Change, TrackingType } from '../src/observableInterfaces';
 import type { Observable } from '../src/observableTypes';
+import { ObservablePersistLocalStorageBase } from '../src/persist-plugins/local-storage';
 
 export interface BasicValue {
     id: string;
@@ -13,6 +13,13 @@ export interface BasicValue {
             baby: string;
         };
     };
+    list?: {
+        parent?: {
+            child: {
+                baby: string;
+            };
+        };
+    }[];
 }
 export interface BasicValue2 {
     id: string;


### PR DESCRIPTION
This PR updates [`src/sync-plugins/crud.ts`](src/sync-plugins/crud.ts) to use deep equality (`deepEqual`) for comparing object values instead of reference comparison in `syncedCrud`.

**Summary:**
- Object fields are now compared by structure, not memory reference.
- Prevents false positives when local and remote objects have equivalent values but different references.
- Fixes buggy sync behavior where values were detected as changed solely due to identity.

Closes https://github.com/LegendApp/legend-state/issues/410.