### PR TITLE
fix: correct create vs update detection logic in syncedCrud

### DIFF
--- a/src/sync-plugins/crud.ts
+++ b/src/sync-plugins/crud.ts
@@ -521,9 +521,9 @@ export function syncedCrud<TRemote extends object, TLocal = TRemote, TAsOption e
                               const isCreate =
                                   !pendingCreates.has(item[fieldId]) &&
                                   (fieldCreatedAt
-                                      ? !item[fieldCreatedAt!] && !prev?.[fieldCreatedAt!]
+                                      ? !prev?.[fieldCreatedAt!]
                                       : fieldUpdatedAt
-                                        ? !item[fieldUpdatedAt] && !prev?.[fieldCreatedAt!]
+                                        ? !item[fieldUpdatedAt] && !prev?.[fieldUpdatedAt!]
                                         : isNullOrUndefined(prev));
                               if (isCreate) {
                                   if (!item[fieldId]) {


### PR DESCRIPTION
## Problem

When using syncedCrud with the list pattern and as: 'array' option, the create vs update detection logic was broken:

- When adding a new item - update was called instead of create
- When updating an existing item - create was called instead of update
      
## Fix

```ts
// Fixed
const isCreate =
    !pendingCreates.has(item[fieldId]) &&
    (fieldCreatedAt
        ? !prev?.[fieldCreatedAt!]  // check server value
        : fieldUpdatedAt
            ? !item[fieldUpdatedAt] && !prev?.[fieldUpdatedAt!]
            : isNullOrUndefined(prev));
```
Key change: For fieldCreatedAt, we now check prev (server value) instead of item (local value). This is correct because when creating an item we don't have createdAt from the server, but we may add it locally.

## Testing

The issue was reproducible with this config:

```ts
syncedCrud({
    as: 'array',
    list: getData,
    create: createEntity,
    update: updateEntity,
    
    fieldCreatedAt: 'createdAt',  // or fieldUpdatedAt
})
```
After the fix, create/update are called correctly.