### PR TITLE
Fix: guard resetPersistence when not initialized in syncState.reset

### DIFF
--- a/src/sync/syncObservable.ts
+++ b/src/sync/syncObservable.ts
@@ -1516,7 +1516,7 @@ export function syncObservable<T>(
         isSubscribed = false;
         unsubscribe?.();
         unsubscribe = undefined;
-        const promise = syncStateValue.resetPersistence();
+        const promise = syncStateValue.resetPersistence?.() ?? Promise.resolve();
         onChangeRemote(() => {
             obs$.set(syncOptions.initial ?? undefined);
         });


### PR DESCRIPTION
Context
When syncStateValue.reset() is called early (before loadLocal initializes persistence), resetPersistence is still undefined. reset() calls syncStateValue.resetPersistence() unconditionally, which throws:
TypeError: syncStateValue.resetPersistence is not a function (it is undefined).

Steps to reproduce

Call syncState(obs).reset() immediately after creating a synced observable.
In async persistence setups, reset can run before loadLocal finishes.
Root cause
resetPersistence is only assigned inside loadLocal(...). Until then it’s undefined, but reset() calls it without a guard.

Change
Replace the direct call with a safe optional call and fallback.

How this fixes it
Prevents the exception and allows reset() to work even when called before persistence initialization, without changing behavior once resetPersistence exists.

Patch

-    const promise = syncStateValue.resetPersistence();
+    const promise = syncStateValue.resetPersistence?.() ?? Promise.resolve();
Notes
This is backward-compatible and no-op when persistence has already been initialized.

If you want me to retry PR creation with a different auth method, tell me what you prefer.