### PR TITLE
fix(undoRedo): clear redo stack when using limit option

### DIFF
--- a/src/helpers/undoRedo.ts
+++ b/src/helpers/undoRedo.ts
@@ -58,11 +58,13 @@ export function undoRedo<T>(obs$: ObservablePrimitive<T>, options?: UndoRedoOpti
         // We're just going to store a copy of the whole object every time it changes.
         const snapshot = internal.clone(obs$.get());
 
+        // Always clear any redo history first (items after current position)
+        history = history.slice(0, historyPointer + 1);
+
+        // Then apply the limit if specified
         if (options?.limit) {
-            // limit means the number of undos
+            // limit means the number of undos, keep the most recent ones
             history = history.slice(Math.max(0, history.length - options.limit));
-        } else {
-            history = history.slice(0, historyPointer + 1);
         }
 
         // we add another history item, which is limit + 1 -- but it's the current one


### PR DESCRIPTION
## Problem

When the `limit` option is set on `undoRedo()`, making a change after undoing does not clear the redo stack. This causes history corruption where undone states persist and can be incorrectly restored.

### Steps to reproduce:
1. Create undoRedo with a limit: `undoRedo(obs$, { limit: 10 })`
2. Make changes: A → B → C
3. Undo (now at B, can redo to C)
4. Make a new change: B → D
5. **Bug:** Redo stack still contains C, history is corrupted

## Root Cause

The original code had mutually exclusive branches:

```typescript
if (options?.limit) {
    // Only keeps last N items - does NOT clear redo stack!
    history = history.slice(Math.max(0, history.length - options.limit));
} else {
    // Correctly clears redo stack
    history = history.slice(0, historyPointer + 1);
}
```

## Solution

Always clear redo history first, then apply the limit separately:

```typescript
// Always clear any redo history first (items after current position)
history = history.slice(0, historyPointer + 1);

// Then apply the limit if specified
if (options?.limit) {
    history = history.slice(Math.max(0, history.length - options.limit));
}
```

## Testing

Added regression test `'Undo/Redo with limit clears redo stack on new change'` that verifies the fix.

All existing tests pass.