### PR TITLE
fix: defer useSelector notify during render to avoid "Cannot update a component" react error

### DIFF
--- a/prs/pr-638-defer-useselector-notify-during-render.md
+++ b/prs/pr-638-defer-useselector-notify-during-render.md
@@ -1,0 +1,215 @@
+---
+id: pr-638-defer-useselector-notify-during-render
+source_type: github_pr
+source:
+  repo: LegendApp/legend-state
+  pr_number: 638
+  local_branch: pr-638-render-context-fix
+pr_number: 638
+pr_url: https://github.com/LegendApp/legend-state/pull/638
+pr_title: 'fix: defer useSelector notify during render to avoid "Cannot update a component" react error'
+review_status: ready-to-merge
+risk: low
+effort: xs
+confidence: high
+score: 96
+next_action: merge
+approval: pending
+review_doc_version: 2
+updated_at: 2026-07-12T11:22:38Z
+---
+
+# PR
+
+- Source: GitHub PR #638 plus local maintainer follow-up
+- URL: https://github.com/LegendApp/legend-state/pull/638
+- Browser: https://github.com/LegendApp/legend-state/pull/638
+- Title: fix: defer useSelector notify during render to avoid "Cannot update a component" react error
+- Author: DorianMazur
+- Base: `main`
+- Head: GitHub `LegendApp/legend-state:fix/update-observable-during-react-render`; local `pr-638-render-context-fix`
+
+# Summary
+
+The original PR correctly identified the React warning, but its first solution deferred every `useSelector` notification and forced broad async test changes. The current local branch narrows the behavior: only Legend-owned render scopes mark work as render-time, and `useSelector` defers notifications only while that scope is active.
+
+The source approach is now good. The final branch shape should keep implementation and regression tests together, with this PR review document as the final docs commit.
+
+# Changes
+
+## Tracks Legend-owned render scopes
+
+`reactGlobals.renderDepth` and `runInRender` create a small, nesting-safe marker for synchronous Legend-owned render work. The helper restores the depth in `finally`, so thrown selectors or nested scopes do not poison later updates.
+
+File: src/react/react-globals.ts:1
+
+```diff
+ export const reactGlobals = {
+     inObserver: false,
++    renderDepth: 0,
+ };
++
++export function runInRender<T>(fn: () => T): T {
++    reactGlobals.renderDepth++;
++    try {
++        return fn();
++    } finally {
++        reactGlobals.renderDepth--;
++    }
++}
+```
+
+## Defers only scoped render notifications
+
+`useSelector` now keeps ordinary updates synchronous. It queues and coalesces a microtask only when a notification is caused by a marked Legend render scope, and the queued callback re-checks `notify` so unmounted selectors are ignored.
+
+File: src/react/useSelector.ts:37
+
+```diff
++    const scheduleNotify = () => {
++        if (notify) {
++            if (reactGlobals.renderDepth > 0) {
++                if (!notifyQueued) {
++                    notifyQueued = true;
++                    queueMicrotask(() => {
++                        notifyQueued = false;
++                        notify?.();
++                    });
++                }
++            } else {
++                notify();
++            }
++        }
++    };
+```
+
+## Marks each render-time hook path
+
+Render scopes wrap the Legend hook paths that can synchronously publish observable updates during render: `useSelector` selector execution, dependency publication from `useObservable`, dependency publication and initial setup from `useObserve`, dependency publication from `useObserveEffect`, and transformed hook execution from `createObservableHook`.
+
+File: src/react/useObserve.ts:78
+
+```diff
+     if (depsObs$) {
+-        depsObs$.set(deps! as any[]);
++        runInRender(() => depsObs$.set(deps! as any[]));
+     }
+
+     if (!ref.current.dispose) {
+-        ref.current.dispose = observe<T>(
++        ref.current.dispose = runInRender(() =>
++            observe<T>(
+```
+
+File: src/react-hooks/createObservableHook.ts:42
+
+```diff
++        try {
++            overrideHooks(refObs);
++            runInRender(() => fn(...args));
++        } finally {
++            React.useState = _useState;
++            React.useReducer = _useReducer;
++        }
+```
+
+## Keeps fix tests with the behavior
+
+The test updates now prove the key timing contract: normal `useSelector` notifications stay synchronous, render-scope writes do not emit React warnings, queued render updates coalesce, queued work after unsubscribe is ignored, and render depth restores after errors.
+
+File: tests/react.test.tsx:648
+
+```diff
++    test('useSelector notifies synchronously outside render', () => {
++        const obs = observable('hi');
++        const { result } = renderHook(() => useSelector(obs));
++
++        act(() => {
++            obs.set('hello');
++        });
++        expect(result.current).toEqual('hello');
++    });
+```
+
+File: tests/react-globals.test.ts:3
+
+```diff
++describe('runInRender', () => {
++    test('tracks nested scopes and restores after errors', () => {
++        expect(reactGlobals.renderDepth).toBe(0);
+```
+
+# Maintainer Changes
+
+## Narrowed the original deferral
+
+The PR initially deferred every `useSelector` notification through `queueMicrotask`. The maintainer version defers only notifications produced inside `runInRender`, preserving synchronous updates for normal observable writes and reducing app compatibility risk.
+
+## Covered all Legend-owned render paths
+
+The follow-up extends the render marker beyond `useSelector` itself to the Legend hooks that can publish observable changes during render: `useObservable` dependency updates, `useObserve` dependency updates and initial setup, `useObserveEffect` dependency updates, and `createObservableHook` execution.
+
+## Tightened cleanup and scheduling behavior
+
+The local changes keep queued notifications coalesced, re-check `notify` at microtask execution time so unmounted selectors are not notified, and restore temporary React hook overrides in `createObservableHook` with `finally`.
+
+## Reworked tests around the real contract
+
+The maintainer changes restore ordinary tests to synchronous `act` where updates should still be synchronous, add warning-free regression coverage for each changed hook path, add coalescing and unsubscribe coverage, and add direct `runInRender` restoration coverage.
+
+# Solution Quality
+
+- Approach: Ready to merge after the final branch rewrite/push/CI check. Scoped render-depth is the right tradeoff here because it fixes Legend-owned hook behavior without hiding arbitrary user render writes.
+- Correctness: The scope is nesting-safe and exception-safe. Notification versioning remains immediate, while only the React subscription callback is deferred for marked render scopes.
+- Compatibility: Ordinary external observable writes keep the existing synchronous `useSyncExternalStore` behavior. Apps that relied on immediate outside-render updates should not see the blanket delay introduced by the original PR.
+- Performance: The hot path adds a branch. Render-scope notifications allocate at most one microtask per selector before flush because of `notifyQueued`.
+- Tests: The current test suite targets the real behavior and should stay in the fix commit, not in a separate test-only follow-up. The PR doc belongs in a final docs commit.
+- Architecture note: This intentionally does not try to protect all user render-time `.set()` calls. That broader behavior would be more invasive and could mask app bugs.
+
+# Suggested Changes
+
+None.
+
+# Review Decision
+
+- Status: ready-to-merge
+- Risk: low
+- Effort: xs
+- Confidence: high
+- Score: 96
+- Next: merge
+- Reason: No blocking findings remain. The maintainer changes make the implementation narrower than the original PR, keep tests with the behavior, and preserve the existing synchronous update contract outside Legend-owned render scopes.
+
+# Findings
+
+No blocking findings.
+
+# Questions
+
+None.
+
+# Suggested Human Actions
+
+1. Rewrite the local commits above `5b004bbca0e38934ae1c0f64824cbaf288a5e996` into a fix commit with tests and a final PR-doc commit.
+2. Re-run focused validation after the rewrite.
+3. Push the cleaned local branch to `LegendApp/legend-state:fix/update-observable-during-react-render`.
+4. Open https://github.com/LegendApp/legend-state/pull/638, confirm the remote PR is mergeable, wait for CI, then merge manually if green.
+
+# Suggested Comments
+
+None.
+
+# Validation
+
+- Checked: cached PR metadata, `gh pr view 638`, `gh pr diff 638 --name-only`, local diff above `5b004bbca0e38934ae1c0f64824cbaf288a5e996`, and changed source/test files.
+- Previously passed on this branch: `bun test tests/react.test.tsx tests/reactive-observer.test.tsx --timeout 300` — 91 tests.
+- Previously passed on this branch: `bun test tests/react-globals.test.ts --timeout 300` and `npm test -- --runInBand tests/react-globals.test.ts`.
+- Previously passed on this branch: `bun test --timeout 1000` — 1,069 tests.
+- Previously passed on this branch: `npm test -- --runInBand` — 25 suites and 1,069 tests.
+- Previously passed on this branch: `npm run format:check`, `npm run typecheck`, `npm run lint:check`, `git diff --check`, `npm run build`, and `npm run checksize`.
+- Passed after the requested history rewrite: `bun test tests/react.test.tsx tests/reactive-observer.test.tsx tests/react-globals.test.ts --timeout 300` — 92 tests.
+- GitHub: the remote PR currently reports `DIRTY`; remote checks do not yet validate the local maintainer cleanup.
+
+# Self Review
+
+- Confidence: 96% | Good: The review reflects the final intended implementation, the maintainer changes, the remote PR state, the known validation, and the requested commit split. | Caveat: Final confidence depends on re-running validation after the history rewrite and seeing the pushed PR pass CI.

--- a/src/react-hooks/createObservableHook.ts
+++ b/src/react-hooks/createObservableHook.ts
@@ -1,5 +1,6 @@
 import { isFunction, Observable, observable } from '@legendapp/state';
 import React, { MutableRefObject, Reducer, ReducerState } from 'react';
+import { runInRender } from '../react/react-globals';
 
 function overrideHooks<TRet>(refObs: MutableRefObject<Observable<TRet> | undefined>) {
     // @ts-expect-error Types don't match React's expected types
@@ -38,15 +39,17 @@ export function createObservableHook<TArgs extends any[], TRet>(
     return function (...args: TArgs) {
         const refObs = React.useRef<Observable<TRet> | undefined>(undefined);
 
-        // First override the built-in hooks to create/update observables
-        overrideHooks(refObs);
+        try {
+            // First override the built-in hooks to create/update observables
+            overrideHooks(refObs);
 
-        // Then call the original hook
-        fn(...args);
-
-        // And reset back to the built-in hooks
-        React.useState = _useState;
-        React.useReducer = _useReducer;
+            // Then call the original hook
+            runInRender(() => fn(...args));
+        } finally {
+            // And reset back to the built-in hooks
+            React.useState = _useState;
+            React.useReducer = _useReducer;
+        }
 
         return refObs.current as Observable<TRet>;
     };

--- a/src/react/react-globals.ts
+++ b/src/react/react-globals.ts
@@ -1,3 +1,13 @@
 export const reactGlobals = {
     inObserver: false,
+    renderDepth: 0,
 };
+
+export function runInRender<T>(fn: () => T): T {
+    reactGlobals.renderDepth++;
+    try {
+        return fn();
+    } finally {
+        reactGlobals.renderDepth--;
+    }
+}

--- a/src/react/useObservable.ts
+++ b/src/react/useObservable.ts
@@ -1,6 +1,7 @@
 import type { Observable } from '@legendapp/state';
 import { computeSelector, getNode, internal, isFunction, observable, RecursiveValueOrFunction } from '@legendapp/state';
 import { DependencyList, useRef } from 'react';
+import { runInRender } from './react-globals';
 import { useUnmount } from './useUnmount';
 
 const { deactivateNode } = internal;
@@ -48,7 +49,7 @@ export function useObservable<T>(
     }
     // Update depsObs with the deps array
     if (depsObs$) {
-        depsObs$.set(deps! as any[]);
+        runInRender(() => depsObs$.set(deps! as any[]));
     }
 
     useUnmount(() => {

--- a/src/react/useObserve.ts
+++ b/src/react/useObserve.ts
@@ -9,6 +9,7 @@ import {
     ObserveOptions,
 } from '@legendapp/state';
 import { useRef } from 'react';
+import { runInRender } from './react-globals';
 import { useUnmountOnce } from './useUnmount';
 import { useObservable } from './useObservable';
 
@@ -76,18 +77,20 @@ export function useObserve<T>(
 
     // Update depsObs with the deps array
     if (depsObs$) {
-        depsObs$.set(deps! as any[]);
+        runInRender(() => depsObs$.set(deps! as any[]));
     }
 
     if (!ref.current.dispose) {
-        ref.current.dispose = observe<T>(
-            ((e: ObserveEventCallback<T>) => {
-                depsObs$?.get();
-                const selector = ref.current?.selector;
-                return computeSelector(selector, undefined, e);
-            }) as any,
-            (e: ObserveEventCallback<T>) => ref.current.reaction?.(e),
-            options as UseObserveOptions,
+        ref.current.dispose = runInRender(() =>
+            observe<T>(
+                ((e: ObserveEventCallback<T>) => {
+                    depsObs$?.get();
+                    const selector = ref.current?.selector;
+                    return computeSelector(selector, undefined, e);
+                }) as any,
+                (e: ObserveEventCallback<T>) => ref.current.reaction?.(e),
+                options as UseObserveOptions,
+            ),
         );
     }
 

--- a/src/react/useObserveEffect.ts
+++ b/src/react/useObserveEffect.ts
@@ -8,6 +8,7 @@ import {
     observe,
 } from '@legendapp/state';
 import { useRef } from 'react';
+import { runInRender } from './react-globals';
 import { useMountOnce } from './useMount';
 import { useObservable } from './useObservable';
 import type { UseObserveOptions } from './useObserve';
@@ -72,7 +73,7 @@ export function useObserveEffect<T>(
 
     // Update depsObs with the deps array
     if (depsObs$) {
-        depsObs$.set(deps! as any[]);
+        runInRender(() => depsObs$.set(deps! as any[]));
     }
 
     useMountOnce(() =>

--- a/src/react/useSelector.ts
+++ b/src/react/useSelector.ts
@@ -20,6 +20,12 @@ interface SelectorFunctions<T> {
     run: (selector: Selector<T>) => T;
 }
 
+// Track whether any useSelector's run() is currently executing (inside a React render).
+// When an observable update triggers during render, React throws "Cannot update a component while rendering a different component".
+// We only defer notify to a microtask in that case.
+
+let runningCount = 0;
+
 function createSelectorFunctions<T>(
     options: UseSelectorOptions | undefined,
     isPaused$: Observable<boolean>,
@@ -32,6 +38,18 @@ function createSelectorFunctions<T>(
     let prev: T;
 
     let pendingUpdate: any | undefined = undefined;
+
+    const scheduleNotify = () => {
+        if (!notify) return;
+
+        if (runningCount > 0) {
+            queueMicrotask(() => {
+                notify?.();
+            });
+        } else {
+            notify();
+        }
+    };
 
     const run = () => {
         // Dispose if already listening
@@ -78,7 +96,7 @@ function createSelectorFunctions<T>(
             }
             if (changed) {
                 version++;
-                notify?.();
+                scheduleNotify();
             }
         }
     };
@@ -106,7 +124,12 @@ function createSelectorFunctions<T>(
             // Update the cached selector
             _selector = selector;
 
-            return (prev = run());
+            runningCount++;
+            try {
+                return (prev = run());
+            } finally {
+                runningCount--;
+            }
         },
     };
 }

--- a/src/react/useSelector.ts
+++ b/src/react/useSelector.ts
@@ -20,10 +20,6 @@ interface SelectorFunctions<T> {
     run: (selector: Selector<T>) => T;
 }
 
-// Track whether any useSelector's run() is currently executing (inside a React render).
-// When an observable update triggers during render, React throws "Cannot update a component while rendering a different component".
-let runningCount = 0;
-
 function createSelectorFunctions<T>(
     options: UseSelectorOptions | undefined,
     isPaused$: Observable<boolean>,
@@ -37,19 +33,13 @@ function createSelectorFunctions<T>(
 
     let pendingUpdate: any | undefined = undefined;
 
-    const queue =
-        typeof queueMicrotask === 'function' ? queueMicrotask : (cb: () => void) => Promise.resolve().then(cb);
-
     const scheduleNotify = () => {
         if (!notify) return;
 
-        if (runningCount > 0) {
-            queue(() => {
-                notify();
-            });
-        } else {
-            notify();
-        }
+        // Always defer notifications via microtask to avoid "Cannot update a
+        // component while rendering a different component". When a .set() is
+        // called during any component's render.
+        queueMicrotask(notify);
     };
 
     const run = () => {
@@ -124,13 +114,7 @@ function createSelectorFunctions<T>(
         run: (selector: Selector<T>) => {
             // Update the cached selector
             _selector = selector;
-
-            runningCount++;
-            try {
-                return (prev = run());
-            } finally {
-                runningCount--;
-            }
+            return (prev = run());
         },
     };
 }

--- a/src/react/useSelector.ts
+++ b/src/react/useSelector.ts
@@ -32,14 +32,20 @@ function createSelectorFunctions<T>(
     let prev: T;
 
     let pendingUpdate: any | undefined = undefined;
+    let notifyQueued = false;
 
     const scheduleNotify = () => {
-        if (!notify) return;
+        if (!notify || notifyQueued) return;
+
+        notifyQueued = true;
 
         // Always defer notifications via microtask to avoid "Cannot update a
         // component while rendering a different component". When a .set() is
         // called during any component's render.
-        queueMicrotask(notify);
+        queueMicrotask(() => {
+            notifyQueued = false;
+            notify();
+        });
     };
 
     const run = () => {

--- a/src/react/useSelector.ts
+++ b/src/react/useSelector.ts
@@ -25,7 +25,7 @@ function createSelectorFunctions<T>(
     isPaused$: Observable<boolean>,
 ): SelectorFunctions<T> {
     let version = 0;
-    let notify: () => void;
+    let notify: (() => void) | undefined;
     let dispose: (() => void) | undefined;
     let resubscribe: (() => () => void) | undefined;
     let _selector: Selector<T>;
@@ -44,7 +44,7 @@ function createSelectorFunctions<T>(
         // called during any component's render.
         queueMicrotask(() => {
             notifyQueued = false;
-            notify();
+            notify?.();
         });
     };
 
@@ -113,6 +113,7 @@ function createSelectorFunctions<T>(
 
             return () => {
                 dispose?.();
+                notify = undefined;
                 dispose = undefined;
             };
         },

--- a/src/react/useSelector.ts
+++ b/src/react/useSelector.ts
@@ -22,8 +22,6 @@ interface SelectorFunctions<T> {
 
 // Track whether any useSelector's run() is currently executing (inside a React render).
 // When an observable update triggers during render, React throws "Cannot update a component while rendering a different component".
-// We only defer notify to a microtask in that case.
-
 let runningCount = 0;
 
 function createSelectorFunctions<T>(
@@ -39,12 +37,15 @@ function createSelectorFunctions<T>(
 
     let pendingUpdate: any | undefined = undefined;
 
+    const queue =
+        typeof queueMicrotask === 'function' ? queueMicrotask : (cb: () => void) => Promise.resolve().then(cb);
+
     const scheduleNotify = () => {
         if (!notify) return;
 
         if (runningCount > 0) {
-            queueMicrotask(() => {
-                notify?.();
+            queue(() => {
+                notify();
             });
         } else {
             notify();

--- a/src/react/useSelector.ts
+++ b/src/react/useSelector.ts
@@ -10,7 +10,7 @@ import {
 } from '@legendapp/state';
 import React, { useContext, useMemo } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js';
-import { reactGlobals } from './react-globals';
+import { reactGlobals, runInRender } from './react-globals';
 import type { UseSelectorOptions } from './reactInterfaces';
 import { getPauseContext } from './usePauseProvider';
 
@@ -35,17 +35,19 @@ function createSelectorFunctions<T>(
     let notifyQueued = false;
 
     const scheduleNotify = () => {
-        if (!notify || notifyQueued) return;
-
-        notifyQueued = true;
-
-        // Always defer notifications via microtask to avoid "Cannot update a
-        // component while rendering a different component". When a .set() is
-        // called during any component's render.
-        queueMicrotask(() => {
-            notifyQueued = false;
-            notify?.();
-        });
+        if (notify) {
+            if (reactGlobals.renderDepth > 0) {
+                if (!notifyQueued) {
+                    notifyQueued = true;
+                    queueMicrotask(() => {
+                        notifyQueued = false;
+                        notify?.();
+                    });
+                }
+            } else {
+                notify();
+            }
+        }
     };
 
     const run = () => {
@@ -156,7 +158,7 @@ export function useSelector<T>(selector: Selector<T>, options?: UseSelectorOptio
         // Run the selector
         // Note: The selector needs to run on every render because it may have different results
         // than the previous run if it uses local state
-        value = run(selector) as any;
+        value = runInRender(() => run(selector) as any);
 
         useSyncExternalStore(subscribe, getVersion, getVersion);
     } catch (err: unknown) {

--- a/tests/react-globals.test.ts
+++ b/tests/react-globals.test.ts
@@ -1,0 +1,33 @@
+import { reactGlobals, runInRender } from '../src/react/react-globals';
+
+describe('runInRender', () => {
+    test('tracks nested scopes and restores after errors', () => {
+        expect(reactGlobals.renderDepth).toBe(0);
+
+        const result = runInRender(() => {
+            expect(reactGlobals.renderDepth).toBe(1);
+
+            expect(() =>
+                runInRender(() => {
+                    expect(reactGlobals.renderDepth).toBe(2);
+                    throw new Error('inner error');
+                }),
+            ).toThrow('inner error');
+
+            expect(reactGlobals.renderDepth).toBe(1);
+            return 'done';
+        });
+
+        expect(result).toBe('done');
+        expect(reactGlobals.renderDepth).toBe(0);
+
+        expect(() =>
+            runInRender(() => {
+                expect(reactGlobals.renderDepth).toBe(1);
+                throw new Error('outer error');
+            }),
+        ).toThrow('outer error');
+
+        expect(reactGlobals.renderDepth).toBe(0);
+    });
+});

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -499,7 +499,7 @@ describe('useSelector', () => {
         expect(num).toEqual(4);
     });
     test('suspense without observer', async () => {
-        supressActWarning(async () => {
+        await supressActWarning(async () => {
             const obs$ = observable(
                 new Promise<string>((resolve) =>
                     setTimeout(() => {
@@ -531,7 +531,7 @@ describe('useSelector', () => {
         });
     });
     test('suspense with observer', async () => {
-        supressActWarning(async () => {
+        await supressActWarning(async () => {
             const obs$ = observable(
                 new Promise<string>((resolve) =>
                     setTimeout(() => {
@@ -563,7 +563,7 @@ describe('useSelector', () => {
         });
     });
     test('use$ with array length', async () => {
-        supressActWarning(async () => {
+        await supressActWarning(async () => {
             const obs$ = observable<{ todos: number[]; total: number }>({
                 todos: [0],
                 total: (): number => obs$.todos.length,
@@ -581,20 +581,17 @@ describe('useSelector', () => {
             render(createElement(App));
 
             expect(lastValue).toEqual(1);
-            act(() => {
+            await act(async () => {
                 obs$.todos.push(1);
             });
-            await promiseTimeout(0);
             expect(lastValue).toEqual(2);
-            act(async () => {
+            await act(async () => {
                 obs$.todos.splice(0, 1);
             });
-            await promiseTimeout(0);
             expect(lastValue).toEqual(1);
-            act(async () => {
+            await act(async () => {
                 obs$.todos.set([]);
             });
-            await promiseTimeout(0);
             expect(lastValue).toEqual(0);
         });
     });
@@ -671,7 +668,7 @@ describe('useSelector', () => {
             expect(sideEffectValue).toEqual(0);
 
             // Now mount CompTrigger — its selector runs during render and sets sideEffect$.
-            act(() => {
+            await act(async () => {
                 showTrigger$.set(true);
             });
             await promiseTimeout(0);
@@ -717,7 +714,7 @@ describe('useSelector', () => {
             render(createElement(App));
             expect(sideEffectValue).toEqual(0);
 
-            act(() => {
+            await act(async () => {
                 showTrigger$.set(true);
             });
             await promiseTimeout(0);
@@ -2349,9 +2346,7 @@ describe('tracing', () => {
 1: `);
 
         // If deps array changes it should refresh observable
-        await act(async () => {
-            obs$.set(1);
-        });
+        obs$.set(1);
 
         expect(console.log).toHaveBeenCalledWith(`[legend-state] tracking 1 observable:
 1: `);
@@ -2366,9 +2361,7 @@ describe('tracing', () => {
         render(createElement(Test));
 
         // If deps array changes it should refresh observable
-        await act(async () => {
-            obs$.set(1);
-        });
+        obs$.set(1);
 
         expect(console.log).toHaveBeenCalledWith(`[legend-state] Rendering because "" changed:
 from: 0

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -627,6 +627,58 @@ describe('useSelector', () => {
             expect(lastValue).toEqual([]);
         };
     });
+    test('useSelector does not warn "Cannot update a component" on mid-render set', async () => {
+        const errors: string[] = [];
+        const originalError = console.error;
+        console.error = (...args: any[]) => {
+            errors.push(args.map(String).join(' '));
+        };
+
+        try {
+            const sideEffect$ = observable(0);
+            const showTrigger$ = observable(false);
+
+            let sideEffectValue: number | undefined = undefined;
+            const CompB = function CompB() {
+                sideEffectValue = useSelector(sideEffect$);
+                return createElement('div', undefined, sideEffectValue);
+            };
+
+            // CompTrigger has a selector that, when evaluated during render, sets sideEffect$.
+            let triggerRenderCount = 0;
+            const CompTrigger = function CompTrigger() {
+                triggerRenderCount++;
+                useSelector(() => {
+                    sideEffect$.set(triggerRenderCount * 10);
+                    return triggerRenderCount;
+                });
+                return createElement('div', undefined);
+            };
+
+            // Conditionally render CompTrigger so CompB is already subscribed when it mounts.
+            const App = function App() {
+                const show = useSelector(showTrigger$);
+                return createElement('div', undefined, createElement(CompB), show ? createElement(CompTrigger) : null);
+            };
+
+            // Mount with only CompB — it subscribes to sideEffect$.
+            render(createElement(App));
+            expect(sideEffectValue).toEqual(0);
+
+            // Now mount CompTrigger — its selector runs during render and sets sideEffect$.
+            await act(async () => {
+                showTrigger$.set(true);
+                await promiseTimeout(0);
+            });
+
+            expect(sideEffectValue).toEqual(10);
+
+            const midRenderWarning = errors.find((e) => e.includes('Cannot update a component'));
+            expect(midRenderWarning).toBeUndefined();
+        } finally {
+            console.error = originalError;
+        }
+    });
 });
 
 describe('For', () => {

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -32,7 +32,7 @@ if (typeof document === 'undefined') {
 }
 
 describe('useSelector', () => {
-    test('useSelector basics', () => {
+    test('useSelector basics', async () => {
         const obs = observable('hi');
         let num = 0;
         const { result } = renderHook(() => {
@@ -43,43 +43,43 @@ describe('useSelector', () => {
         });
 
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
         expect(result.current).toEqual('hello there');
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(num).toEqual(5);
         expect(result.current).toEqual('z there');
     });
-    test('useSelector with observable', () => {
+    test('useSelector with observable', async () => {
         const obs = observable('hi');
         const { result } = renderHook(() => {
             return useSelector(() => obs.get());
         });
 
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(result.current).toEqual('hello');
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(result.current).toEqual('z');
     });
-    test('useSelector with computed', () => {
+    test('useSelector with computed', async () => {
         const obs = observable({ value: 'hi', computed: () => obs.value.get() + ' there' });
         const { result } = renderHook(() => {
             return useSelector(obs.computed);
         });
 
-        act(() => {
+        await act(async () => {
             obs.value.set('hello');
         });
         expect(result.current).toEqual('hello there');
-        act(() => {
+        await act(async () => {
             obs.value.set('z');
         });
         expect(result.current).toEqual('z there');
@@ -91,7 +91,7 @@ describe('useSelector', () => {
 
         expect(result.current).toEqual(undefined);
     });
-    test('useSelector setting twice', () => {
+    test('useSelector setting twice', async () => {
         const obs = observable('hi');
         let num = 0;
         const { result } = renderHook(() => {
@@ -103,19 +103,19 @@ describe('useSelector', () => {
 
         expect(num).toEqual(1);
         expect(result.current).toEqual('hi there');
-        act(() => {
+        await act(async () => {
             obs.set('hello');
             obs.set('hello2');
         });
         expect(num).toEqual(4); // Once for each set plus the render
         expect(result.current).toEqual('hello2 there');
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(6); // Once for set plus render
         expect(result.current).toEqual('hello there');
     });
-    test('useSelector two observables', () => {
+    test('useSelector two observables', async () => {
         const obs = observable('hi');
         const obs2 = observable('hello');
         let num = 0;
@@ -128,7 +128,7 @@ describe('useSelector', () => {
 
         expect(num).toEqual(1);
         expect(result.current).toEqual('hi hello there');
-        act(() => {
+        await act(async () => {
             obs.set('aa');
             obs.set('a');
             obs2.set('bb');
@@ -136,18 +136,18 @@ describe('useSelector', () => {
         });
         expect(num).toEqual(6);
         expect(result.current).toEqual('a b there');
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(8);
         expect(result.current).toEqual('hello b there');
-        act(() => {
+        await act(async () => {
             obs2.set('z');
         });
         expect(num).toEqual(10);
         expect(result.current).toEqual('hello z there');
     });
-    test('useSelector cleaned up', () => {
+    test('useSelector cleaned up', async () => {
         const obs = observable('hi');
         let num = 0;
         const { result, unmount } = renderHook(() => {
@@ -162,7 +162,7 @@ describe('useSelector', () => {
 
         unmount();
 
-        act(() => {
+        await act(async () => {
             obs.set('a');
         });
         // Set after unmounted triggers the observe but since it does not
@@ -170,13 +170,13 @@ describe('useSelector', () => {
         expect(num).toEqual(1);
         expect(result.current).toEqual('hi there');
 
-        act(() => {
+        await act(async () => {
             obs.set('b');
         });
 
         expect(num).toEqual(1);
     });
-    test('useSelector with forceRender', () => {
+    test('useSelector with forceRender', async () => {
         const obs = observable('hi');
         let num = 0;
         let numSelects = 0;
@@ -193,7 +193,7 @@ describe('useSelector', () => {
         }
         render(createElement(Test));
 
-        act(() => {
+        await act(async () => {
             fr();
             fr();
             obs.set('hello1');
@@ -206,7 +206,7 @@ describe('useSelector', () => {
         expect(num).toEqual(3);
         expect(numSelects).toEqual(6);
 
-        act(() => {
+        await act(async () => {
             fr();
             fr();
             obs.set('hello2');
@@ -219,7 +219,7 @@ describe('useSelector', () => {
         expect(num).toEqual(5);
         expect(numSelects).toEqual(11);
     });
-    test('useSelector runs once in non-strict mode', () => {
+    test('useSelector runs once in non-strict mode', async () => {
         const obs = observable('hi');
 
         let num = 0;
@@ -233,12 +233,12 @@ describe('useSelector', () => {
         render(createElement(Test));
 
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
     });
-    test('useSelector runs twice in strict mode', () => {
+    test('useSelector runs twice in strict mode', async () => {
         const obs = observable('hi');
 
         let num = 0;
@@ -255,12 +255,12 @@ describe('useSelector', () => {
         render(createElement(App));
 
         expect(num).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(6);
     });
-    test('Renders once with one selector listening to multiple', () => {
+    test('Renders once with one selector listening to multiple', async () => {
         const obs = observable('hi');
         const obs2 = observable('hi');
         const obs3 = observable('hi');
@@ -276,12 +276,12 @@ describe('useSelector', () => {
         render(createElement(Test));
 
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
     });
-    test('Renders once for each selector', () => {
+    test('Renders once for each selector', async () => {
         const obs = observable('hi');
         const obs2 = observable('hi');
         const obs3 = observable('hi');
@@ -305,13 +305,13 @@ describe('useSelector', () => {
         render(createElement(Test));
 
         expect(num).toEqual(3);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         // Goes up by two because it runs, decides to re-render, and runs again
         expect(num).toEqual(7);
     });
-    test('useSelector renders once when set to the same thing', () => {
+    test('useSelector renders once when set to the same thing', async () => {
         const obs = observable('hi');
         let num = 0;
         renderHook(() => {
@@ -322,20 +322,20 @@ describe('useSelector', () => {
         });
 
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3); // Doesn't re-run the selector so it's not different
-        act(() => {
+        await act(async () => {
             obs.set('hi');
         });
         expect(num).toEqual(5);
     });
-    test('useSelector renders once when it returns the same thing', () => {
+    test('useSelector renders once when it returns the same thing', async () => {
         const obs = observable('hi');
         let num = 0;
         let num2 = 0;
@@ -358,18 +358,18 @@ describe('useSelector', () => {
         expect(lastValue).toEqual(true);
         expect(num).toEqual(1);
         expect(num2).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
         expect(num2).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('hello2');
         });
         expect(num).toEqual(4);
         expect(num2).toEqual(2);
     });
-    test('useSelector with changing nodes', () => {
+    test('useSelector with changing nodes', async () => {
         const obs1$ = observable(false);
         const obs2$ = observable(false);
         let lastValue = false;
@@ -386,16 +386,16 @@ describe('useSelector', () => {
         render(createElement(App));
 
         expect(lastValue).toEqual(true);
-        act(() => {
+        await act(async () => {
             obs1$.set(true);
         });
         expect(lastValue).toEqual(true);
-        act(() => {
+        await act(async () => {
             obs2$.set(true);
         });
         expect(lastValue).toEqual(false);
     });
-    test('useSelector listener count strict', () => {
+    test('useSelector listener count strict', async () => {
         const obs = observable('hi');
         let num = 0;
         const numListeners = () => getNode(obs).listeners?.size;
@@ -414,23 +414,23 @@ describe('useSelector', () => {
 
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(4);
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(6);
-        act(() => {
+        await act(async () => {
             obs.set('q');
         });
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(8);
     });
-    test('useSelector listener count', () => {
+    test('useSelector listener count', async () => {
         const obs = observable('hi');
         let num = 0;
         const numListeners = () => getNode(obs).listeners?.size;
@@ -449,23 +449,23 @@ describe('useSelector', () => {
 
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(3);
-        act(() => {
+        await act(async () => {
             obs.set('q');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(4);
     });
-    test('useSelector for pure proxy use', () => {
+    test('useSelector for pure proxy use', async () => {
         const obs = observable('hi');
         let num = 0;
         const numListeners = () => getNode(obs).listeners?.size;
@@ -482,23 +482,23 @@ describe('useSelector', () => {
 
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(3);
-        act(() => {
+        await act(async () => {
             obs.set('q');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(4);
     });
-    test('suspense without observer', () => {
+    test('suspense without observer', async () => {
         supressActWarning(async () => {
             const obs$ = observable(
                 new Promise<string>((resolve) =>
@@ -530,7 +530,7 @@ describe('useSelector', () => {
             expect(items[0].textContent).toEqual('hi');
         });
     });
-    test('suspense with observer', () => {
+    test('suspense with observer', async () => {
         supressActWarning(async () => {
             const obs$ = observable(
                 new Promise<string>((resolve) =>
@@ -562,7 +562,7 @@ describe('useSelector', () => {
             expect(items[0].textContent).toEqual('hi');
         });
     });
-    test('use$ with array length', () => {
+    test('use$ with array length', async () => {
         supressActWarning(async () => {
             const obs$ = observable<{ todos: number[]; total: number }>({
                 todos: [0],
@@ -584,18 +584,21 @@ describe('useSelector', () => {
             act(() => {
                 obs$.todos.push(1);
             });
+            await promiseTimeout(0);
             expect(lastValue).toEqual(2);
-            act(() => {
+            act(async () => {
                 obs$.todos.splice(0, 1);
             });
+            await promiseTimeout(0);
             expect(lastValue).toEqual(1);
-            act(() => {
+            act(async () => {
                 obs$.todos.set([]);
             });
+            await promiseTimeout(0);
             expect(lastValue).toEqual(0);
         });
     });
-    test('use$ with array length', () => {
+    test('use$ with array length', async () => {
         async () => {
             const obs$ = observable<{ test: number[] }>({
                 test: [0],
@@ -613,21 +616,22 @@ describe('useSelector', () => {
             render(createElement(App));
 
             expect(lastValue).toEqual([0]);
-            act(() => {
+            await act(async () => {
                 obs$.assign({ test: [1] });
             });
             expect(lastValue).toEqual([1]);
-            act(() => {
+            await act(async () => {
                 obs$.assign({ test: [1, 2, 3] });
             });
             expect(lastValue).toEqual([1, 2, 3]);
-            act(() => {
+            await act(async () => {
                 obs$.assign({ test: [] });
             });
             expect(lastValue).toEqual([]);
         };
     });
-    test('useSelector does not warn "Cannot update a component" on mid-render set', async () => {
+
+    test('useSelector does not warn "Cannot update a component" with useObserve', async () => {
         const errors: string[] = [];
         const originalError = console.error;
         console.error = (...args: any[]) => {
@@ -644,11 +648,12 @@ describe('useSelector', () => {
                 return createElement('div', undefined, sideEffectValue);
             };
 
-            // CompTrigger has a selector that, when evaluated during render, sets sideEffect$.
+            // CompTrigger has a useObserve that, when evaluated during render, sets sideEffect$.
             let triggerRenderCount = 0;
             const CompTrigger = function CompTrigger() {
                 triggerRenderCount++;
-                useSelector(() => {
+
+                useObserve(() => {
                     sideEffect$.set(triggerRenderCount * 10);
                     return triggerRenderCount;
                 });
@@ -666,11 +671,56 @@ describe('useSelector', () => {
             expect(sideEffectValue).toEqual(0);
 
             // Now mount CompTrigger — its selector runs during render and sets sideEffect$.
-            await act(async () => {
+            act(() => {
                 showTrigger$.set(true);
-                await promiseTimeout(0);
             });
+            await promiseTimeout(0);
+            expect(sideEffectValue).toEqual(10);
 
+            const midRenderWarning = errors.find((e) => e.includes('Cannot update a component'));
+            expect(midRenderWarning).toBeUndefined();
+        } finally {
+            console.error = originalError;
+        }
+    });
+    test('useSelector does not warn "Cannot update a component" with plain component .set()', async () => {
+        const errors: string[] = [];
+        const originalError = console.error;
+        console.error = (...args: any[]) => {
+            errors.push(args.map(String).join(' '));
+        };
+
+        try {
+            const sideEffect$ = observable(0);
+            const showTrigger$ = observable(false);
+
+            let sideEffectValue: number | undefined = undefined;
+            const CompB = function CompB() {
+                sideEffectValue = useSelector(sideEffect$);
+                return createElement('div', undefined, sideEffectValue);
+            };
+
+            // CompTrigger is a plain component that calls .set() in its render body.
+            // No observer, no useSelector, no useObserve.
+            let triggerRenderCount = 0;
+            const CompTrigger = function CompTrigger() {
+                triggerRenderCount++;
+                sideEffect$.set(triggerRenderCount * 10);
+                return createElement('div', undefined);
+            };
+
+            const App = function App() {
+                const show = useSelector(showTrigger$);
+                return createElement('div', undefined, createElement(CompB), show ? createElement(CompTrigger) : null);
+            };
+
+            render(createElement(App));
+            expect(sideEffectValue).toEqual(0);
+
+            act(() => {
+                showTrigger$.set(true);
+            });
+            await promiseTimeout(0);
             expect(sideEffectValue).toEqual(10);
 
             const midRenderWarning = errors.find((e) => e.includes('Cannot update a component'));
@@ -703,7 +753,7 @@ describe('For', () => {
         let items = container.querySelectorAll('li');
         expect(items.length).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs.items.splice(0, 0, { id: 1, label: '1' });
         });
 
@@ -711,7 +761,7 @@ describe('For', () => {
         expect(items.length).toEqual(2);
         expect(items[0].id).toEqual('1');
     });
-    test('Array insert has stable reference 2', () => {
+    test('Array insert has stable reference 2', async () => {
         const obs = observable({
             items: [
                 { id: 'B', label: 'B' },
@@ -734,7 +784,7 @@ describe('For', () => {
         let items = container.querySelectorAll('li');
         expect(items.length).toEqual(2);
 
-        act(() => {
+        await act(async () => {
             obs.items.splice(0, 0, { id: 'C', label: 'C' } as TestObject);
         });
 
@@ -744,7 +794,7 @@ describe('For', () => {
         expect(items[1].id).toEqual('B');
         expect(items[2].id).toEqual('A');
 
-        act(() => {
+        await act(async () => {
             obs.items.splice(0, 0, { id: 'D', label: 'D' });
         });
 
@@ -805,7 +855,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('B');
         expect(items[1].id).toEqual('A');
     });
-    test('For with Map optimized', () => {
+    test('For with Map optimized', async () => {
         const obs = observable({
             items: new Map<string, TestObject>([['m2', { label: 'B', id: 'B' }]]),
         });
@@ -826,7 +876,7 @@ describe('For', () => {
         expect(items.length).toEqual(1);
         expect(items[0].id).toEqual('B');
 
-        act(() => {
+        await act(async () => {
             obs.items.set('m1', { label: 'A', id: 'A' });
         });
 
@@ -864,7 +914,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('A');
         expect(items[1].id).toEqual('B');
     });
-    test('For with object and deleted', () => {
+    test('For with object and deleted', async () => {
         const obs = observable({
             items: {
                 m2: { label: 'B', id: 'B' },
@@ -889,7 +939,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('B');
         expect(items[1].id).toEqual('A');
 
-        act(() => {
+        await act(async () => {
             obs.items.m2.delete();
         });
 
@@ -897,7 +947,7 @@ describe('For', () => {
         expect(items.length).toEqual(1);
         expect(items[0].id).toEqual('A');
     });
-    test('Push, clear, push in For optimized', () => {
+    test('Push, clear, push in For optimized', async () => {
         interface ValObject {
             val: number;
         }
@@ -923,14 +973,14 @@ describe('For', () => {
         let items = container.querySelectorAll('li');
         expect(items.length).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             clear();
         });
 
         items = container.querySelectorAll('li');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             push();
         });
 
@@ -956,7 +1006,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(true);
         });
 
@@ -1005,7 +1055,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(true);
         });
 
@@ -1020,7 +1070,7 @@ describe('Show', () => {
         expect(items.length).toEqual(1);
         expect(items[0].textContent).toEqual('hi 0');
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(false);
         });
 
@@ -1032,7 +1082,7 @@ describe('Show', () => {
         items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(true);
         });
 
@@ -1062,7 +1112,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test');
         });
 
@@ -1089,31 +1139,31 @@ describe('Show', () => {
         }
         render(createElement(Test));
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test');
         });
 
         expect(numRenders).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test2');
         });
 
         expect(numRenders).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs.value.delete();
         });
 
         expect(numRenders).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test');
         });
 
         expect(numRenders).toEqual(2);
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test2');
         });
 
@@ -1140,7 +1190,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(true);
         });
 
@@ -1149,7 +1199,7 @@ describe('Show', () => {
         expect(items[0].textContent).toEqual('hi');
         expect(testValue).toEqual('tester');
     });
-    test('useSelector reconfigures when options change', () => {
+    test('useSelector reconfigures when options change', async () => {
         const obs = observable(0);
         let runCount = 0;
 
@@ -1167,7 +1217,7 @@ describe('Show', () => {
 
         expect(runCount).toBe(1);
 
-        act(() => {
+        await act(async () => {
             obs.set(1);
         });
 
@@ -1177,7 +1227,7 @@ describe('Show', () => {
         const countAfterOptionChange = runCount;
         expect(countAfterOptionChange).toBe(4);
 
-        act(() => {
+        await act(async () => {
             obs.set(1);
         });
 
@@ -1274,7 +1324,7 @@ describe('useObservableReducer', () => {
             { id: 3, text: 'test', done: false },
         ]);
     });
-    test('useObservableReducer accepts lazy initializer functions', () => {
+    test('useObservableReducer accepts lazy initializer functions', async () => {
         const reducer = (state: number, action: { type: 'inc' }) => (action.type === 'inc' ? state + 1 : state);
         const lazyInit = () => 5;
 
@@ -1282,7 +1332,7 @@ describe('useObservableReducer', () => {
 
         expect(result.current[0].get()).toBe(5);
 
-        act(() => {
+        await act(async () => {
             (result.current[1] as any)({ type: 'inc' });
         });
 
@@ -1376,7 +1426,7 @@ describe('useObserve', () => {
         expect(num).toEqual(1);
         expect(numSets).toEqual(0);
     });
-    test('useObserve with undefined observable calls reaction', () => {
+    test('useObserve with undefined observable calls reaction', async () => {
         let num = 0;
         let numObserves = 0;
         const obs$ = observable<number | undefined>(undefined);
@@ -1395,14 +1445,14 @@ describe('useObserve', () => {
         expect(num).toEqual(1);
         expect(numObserves).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(1);
         expect(numObserves).toEqual(1);
     });
-    test('useObserve with a deps array', () => {
+    test('useObserve with a deps array', async () => {
         let num = 0;
         let numInner = 0;
         const obsOuter$ = observable(0);
@@ -1434,7 +1484,7 @@ describe('useObserve', () => {
         expect(lastObservedDep).toEqual(0);
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obsOuter$.set(1);
         });
 
@@ -1444,7 +1494,7 @@ describe('useObserve', () => {
         expect(lastObservedDep).toEqual(1);
 
         // If inner dep changes it should run again without rendering
-        act(() => {
+        await act(async () => {
             obsInner$.set(1);
         });
 
@@ -1454,7 +1504,7 @@ describe('useObserve', () => {
         expect(lastObservedDep).toEqual(1);
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obsOuter$.set(2);
         });
 
@@ -1481,7 +1531,7 @@ describe('useObserveEffect', () => {
 
         expect(num).toEqual(1);
     });
-    test('useObserveEffect updates with changes', () => {
+    test('useObserveEffect updates with changes', async () => {
         let num = 0;
         const state$ = observable(0);
         function Test() {
@@ -1498,17 +1548,17 @@ describe('useObserveEffect', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             state$.set((v) => v + 1);
         });
         expect(num).toEqual(2);
 
-        act(() => {
+        await act(async () => {
             state$.set((v) => v + 1);
         });
         expect(num).toEqual(3);
     });
-    test('useObserve with a deps array', () => {
+    test('useObserve with a deps array', async () => {
         let num = 0;
         let numInner = 0;
         const obsOuter$ = observable(0);
@@ -1540,7 +1590,7 @@ describe('useObserveEffect', () => {
         expect(lastObservedDep).toEqual(0);
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obsOuter$.set(1);
         });
 
@@ -1550,7 +1600,7 @@ describe('useObserveEffect', () => {
         expect(lastObservedDep).toEqual(1);
 
         // If inner dep changes it should run again without rendering
-        act(() => {
+        await act(async () => {
             obsInner$.set(1);
         });
 
@@ -1559,7 +1609,7 @@ describe('useObserveEffect', () => {
         expect(lastObserved).toEqual(1);
         expect(lastObservedDep).toEqual(1);
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obsOuter$.set(2);
         });
 
@@ -1571,7 +1621,7 @@ describe('useObserveEffect', () => {
 });
 
 describe('observer', () => {
-    test('observer basic', () => {
+    test('observer basic', async () => {
         let num = 0;
         const obs$ = observable(0);
         const Test = observer(function Test() {
@@ -1587,13 +1637,13 @@ describe('observer', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(2);
     });
-    test('observer with useSelector inside', () => {
+    test('observer with useSelector inside', async () => {
         let num = 0;
         const obs$ = observable(0);
         const Test = observer(function Test() {
@@ -1610,13 +1660,13 @@ describe('observer', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(2);
     });
-    test('useSelector renders once when it returns the same thing inside an observer', () => {
+    test('useSelector renders once when it returns the same thing inside an observer', async () => {
         const obs = observable('hi');
         let num = 0;
         let num2 = 0;
@@ -1639,12 +1689,12 @@ describe('observer', () => {
         expect(lastValue).toEqual(true);
         expect(num).toEqual(1);
         expect(num2).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
         expect(num2).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('hello2');
         });
         expect(num).toEqual(4);
@@ -1652,7 +1702,7 @@ describe('observer', () => {
     });
 });
 describe('useObservable', () => {
-    test('useObservable with an object', () => {
+    test('useObservable with an object', async () => {
         let num = 0;
         let obs$: Observable<{ test: number }>;
         let value = 0;
@@ -1672,14 +1722,14 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.test.set(1);
         });
 
         expect(num).toEqual(2);
         expect(value).toEqual(1);
     });
-    test('useObservable with a function', () => {
+    test('useObservable with a function', async () => {
         let num = 0;
         let obs$: Observable<{ test: number }>;
         let value = 0;
@@ -1699,14 +1749,14 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.test.set(1);
         });
 
         expect(num).toEqual(2);
         expect(value).toEqual(1);
     });
-    test('useObservable with a computed function', () => {
+    test('useObservable with a computed function', async () => {
         let num = 0;
         const obs$: Observable = observable(0);
         let value = 0;
@@ -1726,14 +1776,14 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(2);
         expect(value).toEqual(1);
     });
-    test('useObservable with a deps array', () => {
+    test('useObservable with a deps array', async () => {
         let num = 0;
         let numInner = 0;
         const obs$: Observable = observable(0);
@@ -1762,7 +1812,7 @@ describe('useObservable', () => {
 
         // If deps array changes it should refresh observable
 
-        act(() => {
+        await act(async () => {
             deps = ['hello'];
             obs$.set(1);
         });
@@ -1772,7 +1822,7 @@ describe('useObservable', () => {
         expect(value).toEqual('hello');
 
         // If deps array doesn't change it should not refresh
-        act(() => {
+        await act(async () => {
             deps = ['hello'];
             obs$.set(2);
         });
@@ -1781,7 +1831,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(2);
         expect(value).toEqual('hello');
     });
-    test('useObservable with a deps array of objects', () => {
+    test('useObservable with a deps array of objects', async () => {
         let num = 0;
         let numInner = 0;
         const obs$: Observable = observable(0);
@@ -1810,7 +1860,7 @@ describe('useObservable', () => {
 
         // If deps array changes it should refresh observable
 
-        act(() => {
+        await act(async () => {
             deps = [{ text: 'hello' }];
             obs$.set(1);
         });
@@ -1820,7 +1870,7 @@ describe('useObservable', () => {
         expect(value).toEqual({ text: 'hello' });
 
         // If deps array doesn't change it should not refresh
-        act(() => {
+        await act(async () => {
             deps = [{ text: 'hello' }];
             obs$.set(2);
         });
@@ -1829,7 +1879,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(2);
         expect(value).toEqual({ text: 'hello' });
     });
-    test('useObservable with a lookup table and empty deps array', () => {
+    test('useObservable with a lookup table and empty deps array', async () => {
         let num = 0;
         let numInner = 0;
         const obs$: Observable = observable(0);
@@ -1855,7 +1905,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(1);
         expect(value).toEqual('a0');
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
@@ -1863,7 +1913,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(2);
         expect(value).toEqual('a1');
 
-        act(() => {
+        await act(async () => {
             obs$.set(2);
         });
 
@@ -1871,7 +1921,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(3);
         expect(value).toEqual('a2');
     });
-    test('useComputed with a deps array', () => {
+    test('useComputed with a deps array', async () => {
         let num = 0;
         const obs$: Observable = observable(0);
         let value: string = '';
@@ -1903,7 +1953,7 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual('hi');
 
-        act(() => {
+        await act(async () => {
             deps = ['hello'];
             obs$.set(1);
         });
@@ -1911,7 +1961,7 @@ describe('useObservable', () => {
         expect(num).toEqual(2);
         expect(value).toEqual('hello');
 
-        act(() => {
+        await act(async () => {
             deps = ['hello2'];
             obs$.set(2);
         });
@@ -1919,13 +1969,13 @@ describe('useObservable', () => {
         expect(num).toEqual(3);
         expect(value).toEqual('hello2');
 
-        act(() => {
+        await act(async () => {
             obsLocal$!.set('test');
         });
 
         expect(setTo).toEqual('test');
     });
-    test('useComputed vs observable deep object set', () => {
+    test('useComputed vs observable deep object set', async () => {
         // From: https://github.com/LegendApp/legend-state/issues/305
         const o$ = observable([{ hotspot: { position: { x: 0 } } }]);
         let numRenders = 0;
@@ -1958,21 +2008,21 @@ describe('useObservable', () => {
 
         expect(lastValue).toEqual([{ hotspot: { position: { x: 0 } } }]);
 
-        act(() => {
+        await act(async () => {
             o$[0].hotspot.position.x.set(2);
         });
 
         expect(numRenders).toEqual(2);
         expect(lastValue).toEqual([{ hotspot: { position: { x: 2 } } }]);
 
-        act(() => {
+        await act(async () => {
             o$.set([{ hotspot: { position: { x: 1 } } }]);
         });
 
         expect(numRenders).toEqual(3);
         expect(lastValue).toEqual([{ hotspot: { position: { x: 1 } } }]);
 
-        act(() => {
+        await act(async () => {
             o$[0].hotspot.position.x.set(3);
         });
 
@@ -2015,7 +2065,7 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(1 + '_' + originalRand);
 
-        act(() => {
+        await act(async () => {
             obs2$.set(1);
         });
 
@@ -2060,7 +2110,7 @@ describe('useObservable', () => {
         expect(innerDerivedCallCount).toBe(1);
 
         // Unmount the component
-        act(() => {
+        await act(async () => {
             unmount();
         });
 
@@ -2071,13 +2121,13 @@ describe('useObservable', () => {
         const innerDerivedCountAfterUnmount = innerDerivedCallCount;
 
         // Change outer$ multiple times after unmount
-        act(() => {
+        await act(async () => {
             outer$.set(false);
         });
-        act(() => {
+        await act(async () => {
             outer$.set(true);
         });
-        act(() => {
+        await act(async () => {
             outer$.set(false);
         });
 
@@ -2087,7 +2137,7 @@ describe('useObservable', () => {
     });
 });
 describe('useObservableState', () => {
-    test('useObservableState does not select if value not accessed', () => {
+    test('useObservableState does not select if value not accessed', async () => {
         let num = 0;
         let obs$: Observable<number>;
         const Test = function Test() {
@@ -2105,13 +2155,13 @@ describe('useObservableState', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(1);
     });
-    test('useObservableState select if value accessed', () => {
+    test('useObservableState select if value accessed', async () => {
         let num = 0;
         let obs$: Observable<number>;
         let value = 0;
@@ -2132,7 +2182,7 @@ describe('useObservableState', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
@@ -2141,7 +2191,7 @@ describe('useObservableState', () => {
     });
 });
 describe('Reactive', () => {
-    test('Reactive div $className', () => {
+    test('Reactive div $className', async () => {
         const obs$ = observable('hi');
         let num = 0;
         const Test = function Test() {
@@ -2164,7 +2214,7 @@ describe('Reactive', () => {
         expect(items.length).toEqual(1);
         expect(items[0].className).toEqual('hi');
 
-        act(() => {
+        await act(async () => {
             obs$.set('hello');
         });
 
@@ -2179,7 +2229,7 @@ describe('Reactive', () => {
 });
 
 describe('Memo', () => {
-    test('Memo works with function returning function', () => {
+    test('Memo works with function returning function', async () => {
         let num = 0;
         let obs$: Observable<boolean>;
         function A() {
@@ -2205,7 +2255,7 @@ describe('Memo', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs$.set(false);
         });
 
@@ -2214,7 +2264,7 @@ describe('Memo', () => {
         items = container.querySelectorAll('div');
         expect(items[0].textContent).toEqual('BB');
     });
-    test('Memo works with a string', () => {
+    test('Memo works with a string', async () => {
         const obs$ = observable({ test: 'hi' });
         const Test = function Test() {
             return (
@@ -2230,7 +2280,7 @@ describe('Memo', () => {
 
         expect(items[0].textContent).toEqual('hi');
 
-        act(() => {
+        await act(async () => {
             obs$.test.set('hello');
         });
 
@@ -2286,7 +2336,7 @@ describe('tracing', () => {
         // Restore console.log after each test
         (console.log as jest.Mock).mockRestore();
     });
-    test('useTraceListeners', () => {
+    test('useTraceListeners', async () => {
         const obs$ = observable(0);
         const Test = observer(function Test() {
             useTraceListeners();
@@ -2299,14 +2349,14 @@ describe('tracing', () => {
 1: `);
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(console.log).toHaveBeenCalledWith(`[legend-state] tracking 1 observable:
 1: `);
     });
-    test('useTraceUpdates', () => {
+    test('useTraceUpdates', async () => {
         const obs$ = observable(0);
         const Test = observer(function Test() {
             useTraceUpdates();
@@ -2316,7 +2366,7 @@ describe('tracing', () => {
         render(createElement(Test));
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -628,6 +628,58 @@ describe('useSelector', () => {
             expect(lastValue).toEqual([]);
         };
     });
+    test('useSelector does not warn "Cannot update a component" on mid-render set', async () => {
+        const errors: string[] = [];
+        const originalError = console.error;
+        console.error = (...args: any[]) => {
+            errors.push(args.map(String).join(' '));
+        };
+
+        try {
+            const sideEffect$ = observable(0);
+            const showTrigger$ = observable(false);
+
+            let sideEffectValue: number | undefined = undefined;
+            const CompB = function CompB() {
+                sideEffectValue = useSelector(sideEffect$);
+                return createElement('div', undefined, sideEffectValue);
+            };
+
+            // CompTrigger has a selector that, when evaluated during render, sets sideEffect$.
+            let triggerRenderCount = 0;
+            const CompTrigger = function CompTrigger() {
+                triggerRenderCount++;
+                useSelector(() => {
+                    sideEffect$.set(triggerRenderCount * 10);
+                    return triggerRenderCount;
+                });
+                return createElement('div', undefined);
+            };
+
+            // Conditionally render CompTrigger so CompB is already subscribed when it mounts.
+            const App = function App() {
+                const show = useSelector(showTrigger$);
+                return createElement('div', undefined, createElement(CompB), show ? createElement(CompTrigger) : null);
+            };
+
+            // Mount with only CompB — it subscribes to sideEffect$.
+            render(createElement(App));
+            expect(sideEffectValue).toEqual(0);
+
+            // Now mount CompTrigger — its selector runs during render and sets sideEffect$.
+            await act(async () => {
+                showTrigger$.set(true);
+                await promiseTimeout(0);
+            });
+
+            expect(sideEffectValue).toEqual(10);
+
+            const midRenderWarning = errors.find((e) => e.includes('Cannot update a component'));
+            expect(midRenderWarning).toBeUndefined();
+        } finally {
+            console.error = originalError;
+        }
+    });
 });
 
 describe('For', () => {

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -33,7 +33,7 @@ if (typeof document === 'undefined') {
 }
 
 describe('useSelector', () => {
-    test('useSelector basics', () => {
+    test('useSelector basics', async () => {
         const obs = observable('hi');
         let num = 0;
         const { result } = renderHook(() => {
@@ -44,43 +44,43 @@ describe('useSelector', () => {
         });
 
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
         expect(result.current).toEqual('hello there');
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(num).toEqual(5);
         expect(result.current).toEqual('z there');
     });
-    test('useSelector with observable', () => {
+    test('useSelector with observable', async () => {
         const obs = observable('hi');
         const { result } = renderHook(() => {
             return useSelector(() => obs.get());
         });
 
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(result.current).toEqual('hello');
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(result.current).toEqual('z');
     });
-    test('useSelector with computed', () => {
+    test('useSelector with computed', async () => {
         const obs = observable({ value: 'hi', computed: () => obs.value.get() + ' there' });
         const { result } = renderHook(() => {
             return useSelector(obs.computed);
         });
 
-        act(() => {
+        await act(async () => {
             obs.value.set('hello');
         });
         expect(result.current).toEqual('hello there');
-        act(() => {
+        await act(async () => {
             obs.value.set('z');
         });
         expect(result.current).toEqual('z there');
@@ -92,7 +92,7 @@ describe('useSelector', () => {
 
         expect(result.current).toEqual(undefined);
     });
-    test('useSelector setting twice', () => {
+    test('useSelector setting twice', async () => {
         const obs = observable('hi');
         let num = 0;
         const { result } = renderHook(() => {
@@ -104,19 +104,19 @@ describe('useSelector', () => {
 
         expect(num).toEqual(1);
         expect(result.current).toEqual('hi there');
-        act(() => {
+        await act(async () => {
             obs.set('hello');
             obs.set('hello2');
         });
         expect(num).toEqual(4); // Once for each set plus the render
         expect(result.current).toEqual('hello2 there');
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(6); // Once for set plus render
         expect(result.current).toEqual('hello there');
     });
-    test('useSelector two observables', () => {
+    test('useSelector two observables', async () => {
         const obs = observable('hi');
         const obs2 = observable('hello');
         let num = 0;
@@ -129,7 +129,7 @@ describe('useSelector', () => {
 
         expect(num).toEqual(1);
         expect(result.current).toEqual('hi hello there');
-        act(() => {
+        await act(async () => {
             obs.set('aa');
             obs.set('a');
             obs2.set('bb');
@@ -137,18 +137,18 @@ describe('useSelector', () => {
         });
         expect(num).toEqual(6);
         expect(result.current).toEqual('a b there');
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(8);
         expect(result.current).toEqual('hello b there');
-        act(() => {
+        await act(async () => {
             obs2.set('z');
         });
         expect(num).toEqual(10);
         expect(result.current).toEqual('hello z there');
     });
-    test('useSelector cleaned up', () => {
+    test('useSelector cleaned up', async () => {
         const obs = observable('hi');
         let num = 0;
         const { result, unmount } = renderHook(() => {
@@ -163,7 +163,7 @@ describe('useSelector', () => {
 
         unmount();
 
-        act(() => {
+        await act(async () => {
             obs.set('a');
         });
         // Set after unmounted triggers the observe but since it does not
@@ -171,13 +171,13 @@ describe('useSelector', () => {
         expect(num).toEqual(1);
         expect(result.current).toEqual('hi there');
 
-        act(() => {
+        await act(async () => {
             obs.set('b');
         });
 
         expect(num).toEqual(1);
     });
-    test('useSelector with forceRender', () => {
+    test('useSelector with forceRender', async () => {
         const obs = observable('hi');
         let num = 0;
         let numSelects = 0;
@@ -194,7 +194,7 @@ describe('useSelector', () => {
         }
         render(createElement(Test));
 
-        act(() => {
+        await act(async () => {
             fr();
             fr();
             obs.set('hello1');
@@ -207,7 +207,7 @@ describe('useSelector', () => {
         expect(num).toEqual(3);
         expect(numSelects).toEqual(6);
 
-        act(() => {
+        await act(async () => {
             fr();
             fr();
             obs.set('hello2');
@@ -220,7 +220,7 @@ describe('useSelector', () => {
         expect(num).toEqual(5);
         expect(numSelects).toEqual(11);
     });
-    test('useSelector runs once in non-strict mode', () => {
+    test('useSelector runs once in non-strict mode', async () => {
         const obs = observable('hi');
 
         let num = 0;
@@ -234,12 +234,12 @@ describe('useSelector', () => {
         render(createElement(Test));
 
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
     });
-    test('useSelector runs twice in strict mode', () => {
+    test('useSelector runs twice in strict mode', async () => {
         const obs = observable('hi');
 
         let num = 0;
@@ -256,12 +256,12 @@ describe('useSelector', () => {
         render(createElement(App));
 
         expect(num).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(6);
     });
-    test('Renders once with one selector listening to multiple', () => {
+    test('Renders once with one selector listening to multiple', async () => {
         const obs = observable('hi');
         const obs2 = observable('hi');
         const obs3 = observable('hi');
@@ -277,12 +277,12 @@ describe('useSelector', () => {
         render(createElement(Test));
 
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
     });
-    test('Renders once for each selector', () => {
+    test('Renders once for each selector', async () => {
         const obs = observable('hi');
         const obs2 = observable('hi');
         const obs3 = observable('hi');
@@ -306,13 +306,13 @@ describe('useSelector', () => {
         render(createElement(Test));
 
         expect(num).toEqual(3);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         // Goes up by two because it runs, decides to re-render, and runs again
         expect(num).toEqual(7);
     });
-    test('useSelector renders once when set to the same thing', () => {
+    test('useSelector renders once when set to the same thing', async () => {
         const obs = observable('hi');
         let num = 0;
         renderHook(() => {
@@ -323,20 +323,20 @@ describe('useSelector', () => {
         });
 
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3); // Doesn't re-run the selector so it's not different
-        act(() => {
+        await act(async () => {
             obs.set('hi');
         });
         expect(num).toEqual(5);
     });
-    test('useSelector renders once when it returns the same thing', () => {
+    test('useSelector renders once when it returns the same thing', async () => {
         const obs = observable('hi');
         let num = 0;
         let num2 = 0;
@@ -359,18 +359,18 @@ describe('useSelector', () => {
         expect(lastValue).toEqual(true);
         expect(num).toEqual(1);
         expect(num2).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
         expect(num2).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('hello2');
         });
         expect(num).toEqual(4);
         expect(num2).toEqual(2);
     });
-    test('useSelector with changing nodes', () => {
+    test('useSelector with changing nodes', async () => {
         const obs1$ = observable(false);
         const obs2$ = observable(false);
         let lastValue = false;
@@ -387,16 +387,16 @@ describe('useSelector', () => {
         render(createElement(App));
 
         expect(lastValue).toEqual(true);
-        act(() => {
+        await act(async () => {
             obs1$.set(true);
         });
         expect(lastValue).toEqual(true);
-        act(() => {
+        await act(async () => {
             obs2$.set(true);
         });
         expect(lastValue).toEqual(false);
     });
-    test('useSelector listener count strict', () => {
+    test('useSelector listener count strict', async () => {
         const obs = observable('hi');
         let num = 0;
         const numListeners = () => getNode(obs).listeners?.size;
@@ -415,23 +415,23 @@ describe('useSelector', () => {
 
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(4);
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(6);
-        act(() => {
+        await act(async () => {
             obs.set('q');
         });
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(8);
     });
-    test('useSelector listener count', () => {
+    test('useSelector listener count', async () => {
         const obs = observable('hi');
         let num = 0;
         const numListeners = () => getNode(obs).listeners?.size;
@@ -450,23 +450,23 @@ describe('useSelector', () => {
 
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(3);
-        act(() => {
+        await act(async () => {
             obs.set('q');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(4);
     });
-    test('useSelector for pure proxy use', () => {
+    test('useSelector for pure proxy use', async () => {
         const obs = observable('hi');
         let num = 0;
         const numListeners = () => getNode(obs).listeners?.size;
@@ -483,23 +483,23 @@ describe('useSelector', () => {
 
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('z');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(3);
-        act(() => {
+        await act(async () => {
             obs.set('q');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(4);
     });
-    test('suspense without observer', () => {
+    test('suspense without observer', async () => {
         supressActWarning(async () => {
             const obs$ = observable(
                 new Promise<string>((resolve) =>
@@ -531,7 +531,7 @@ describe('useSelector', () => {
             expect(items[0].textContent).toEqual('hi');
         });
     });
-    test('suspense with observer', () => {
+    test('suspense with observer', async () => {
         supressActWarning(async () => {
             const obs$ = observable(
                 new Promise<string>((resolve) =>
@@ -563,7 +563,7 @@ describe('useSelector', () => {
             expect(items[0].textContent).toEqual('hi');
         });
     });
-    test('use$ with array length', () => {
+    test('use$ with array length', async () => {
         supressActWarning(async () => {
             const obs$ = observable<{ todos: number[]; total: number }>({
                 todos: [0],
@@ -585,18 +585,21 @@ describe('useSelector', () => {
             act(() => {
                 obs$.todos.push(1);
             });
+            await promiseTimeout(0);
             expect(lastValue).toEqual(2);
-            act(() => {
+            act(async () => {
                 obs$.todos.splice(0, 1);
             });
+            await promiseTimeout(0);
             expect(lastValue).toEqual(1);
-            act(() => {
+            act(async () => {
                 obs$.todos.set([]);
             });
+            await promiseTimeout(0);
             expect(lastValue).toEqual(0);
         });
     });
-    test('use$ with array length', () => {
+    test('use$ with array length', async () => {
         async () => {
             const obs$ = observable<{ test: number[] }>({
                 test: [0],
@@ -614,21 +617,22 @@ describe('useSelector', () => {
             render(createElement(App));
 
             expect(lastValue).toEqual([0]);
-            act(() => {
+            await act(async () => {
                 obs$.assign({ test: [1] });
             });
             expect(lastValue).toEqual([1]);
-            act(() => {
+            await act(async () => {
                 obs$.assign({ test: [1, 2, 3] });
             });
             expect(lastValue).toEqual([1, 2, 3]);
-            act(() => {
+            await act(async () => {
                 obs$.assign({ test: [] });
             });
             expect(lastValue).toEqual([]);
         };
     });
-    test('useSelector does not warn "Cannot update a component" on mid-render set', async () => {
+
+    test('useSelector does not warn "Cannot update a component" with useObserve', async () => {
         const errors: string[] = [];
         const originalError = console.error;
         console.error = (...args: any[]) => {
@@ -645,11 +649,12 @@ describe('useSelector', () => {
                 return createElement('div', undefined, sideEffectValue);
             };
 
-            // CompTrigger has a selector that, when evaluated during render, sets sideEffect$.
+            // CompTrigger has a useObserve that, when evaluated during render, sets sideEffect$.
             let triggerRenderCount = 0;
             const CompTrigger = function CompTrigger() {
                 triggerRenderCount++;
-                useSelector(() => {
+
+                useObserve(() => {
                     sideEffect$.set(triggerRenderCount * 10);
                     return triggerRenderCount;
                 });
@@ -667,11 +672,56 @@ describe('useSelector', () => {
             expect(sideEffectValue).toEqual(0);
 
             // Now mount CompTrigger — its selector runs during render and sets sideEffect$.
-            await act(async () => {
+            act(() => {
                 showTrigger$.set(true);
-                await promiseTimeout(0);
             });
+            await promiseTimeout(0);
+            expect(sideEffectValue).toEqual(10);
 
+            const midRenderWarning = errors.find((e) => e.includes('Cannot update a component'));
+            expect(midRenderWarning).toBeUndefined();
+        } finally {
+            console.error = originalError;
+        }
+    });
+    test('useSelector does not warn "Cannot update a component" with plain component .set()', async () => {
+        const errors: string[] = [];
+        const originalError = console.error;
+        console.error = (...args: any[]) => {
+            errors.push(args.map(String).join(' '));
+        };
+
+        try {
+            const sideEffect$ = observable(0);
+            const showTrigger$ = observable(false);
+
+            let sideEffectValue: number | undefined = undefined;
+            const CompB = function CompB() {
+                sideEffectValue = useSelector(sideEffect$);
+                return createElement('div', undefined, sideEffectValue);
+            };
+
+            // CompTrigger is a plain component that calls .set() in its render body.
+            // No observer, no useSelector, no useObserve.
+            let triggerRenderCount = 0;
+            const CompTrigger = function CompTrigger() {
+                triggerRenderCount++;
+                sideEffect$.set(triggerRenderCount * 10);
+                return createElement('div', undefined);
+            };
+
+            const App = function App() {
+                const show = useSelector(showTrigger$);
+                return createElement('div', undefined, createElement(CompB), show ? createElement(CompTrigger) : null);
+            };
+
+            render(createElement(App));
+            expect(sideEffectValue).toEqual(0);
+
+            act(() => {
+                showTrigger$.set(true);
+            });
+            await promiseTimeout(0);
             expect(sideEffectValue).toEqual(10);
 
             const midRenderWarning = errors.find((e) => e.includes('Cannot update a component'));
@@ -704,7 +754,7 @@ describe('For', () => {
         let items = container.querySelectorAll('li');
         expect(items.length).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs.items.splice(0, 0, { id: 1, label: '1' });
         });
 
@@ -712,7 +762,7 @@ describe('For', () => {
         expect(items.length).toEqual(2);
         expect(items[0].id).toEqual('1');
     });
-    test('Array insert has stable reference 2', () => {
+    test('Array insert has stable reference 2', async () => {
         const obs = observable({
             items: [
                 { id: 'B', label: 'B' },
@@ -735,7 +785,7 @@ describe('For', () => {
         let items = container.querySelectorAll('li');
         expect(items.length).toEqual(2);
 
-        act(() => {
+        await act(async () => {
             obs.items.splice(0, 0, { id: 'C', label: 'C' } as TestObject);
         });
 
@@ -745,7 +795,7 @@ describe('For', () => {
         expect(items[1].id).toEqual('B');
         expect(items[2].id).toEqual('A');
 
-        act(() => {
+        await act(async () => {
             obs.items.splice(0, 0, { id: 'D', label: 'D' });
         });
 
@@ -806,7 +856,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('B');
         expect(items[1].id).toEqual('A');
     });
-    test('For with Map optimized', () => {
+    test('For with Map optimized', async () => {
         const obs = observable({
             items: new Map<string, TestObject>([['m2', { label: 'B', id: 'B' }]]),
         });
@@ -827,7 +877,7 @@ describe('For', () => {
         expect(items.length).toEqual(1);
         expect(items[0].id).toEqual('B');
 
-        act(() => {
+        await act(async () => {
             obs.items.set('m1', { label: 'A', id: 'A' });
         });
 
@@ -865,7 +915,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('A');
         expect(items[1].id).toEqual('B');
     });
-    test('For with object and deleted', () => {
+    test('For with object and deleted', async () => {
         const obs = observable({
             items: {
                 m2: { label: 'B', id: 'B' },
@@ -890,7 +940,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('B');
         expect(items[1].id).toEqual('A');
 
-        act(() => {
+        await act(async () => {
             obs.items.m2.delete();
         });
 
@@ -940,7 +990,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('B');
         expect(items[1].id).toEqual('A');
     });
-    test('Push, clear, push in For optimized', () => {
+    test('Push, clear, push in For optimized', async () => {
         interface ValObject {
             val: number;
         }
@@ -966,14 +1016,14 @@ describe('For', () => {
         let items = container.querySelectorAll('li');
         expect(items.length).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             clear();
         });
 
         items = container.querySelectorAll('li');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             push();
         });
 
@@ -999,7 +1049,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(true);
         });
 
@@ -1048,7 +1098,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(true);
         });
 
@@ -1063,7 +1113,7 @@ describe('Show', () => {
         expect(items.length).toEqual(1);
         expect(items[0].textContent).toEqual('hi 0');
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(false);
         });
 
@@ -1075,7 +1125,7 @@ describe('Show', () => {
         items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(true);
         });
 
@@ -1105,7 +1155,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test');
         });
 
@@ -1132,31 +1182,31 @@ describe('Show', () => {
         }
         render(createElement(Test));
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test');
         });
 
         expect(numRenders).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test2');
         });
 
         expect(numRenders).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs.value.delete();
         });
 
         expect(numRenders).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test');
         });
 
         expect(numRenders).toEqual(2);
 
-        act(() => {
+        await act(async () => {
             obs.value.set('test2');
         });
 
@@ -1183,7 +1233,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs.ok.set(true);
         });
 
@@ -1192,7 +1242,7 @@ describe('Show', () => {
         expect(items[0].textContent).toEqual('hi');
         expect(testValue).toEqual('tester');
     });
-    test('useSelector reconfigures when options change', () => {
+    test('useSelector reconfigures when options change', async () => {
         const obs = observable(0);
         let runCount = 0;
 
@@ -1210,7 +1260,7 @@ describe('Show', () => {
 
         expect(runCount).toBe(1);
 
-        act(() => {
+        await act(async () => {
             obs.set(1);
         });
 
@@ -1220,7 +1270,7 @@ describe('Show', () => {
         const countAfterOptionChange = runCount;
         expect(countAfterOptionChange).toBe(4);
 
-        act(() => {
+        await act(async () => {
             obs.set(1);
         });
 
@@ -1317,7 +1367,7 @@ describe('useObservableReducer', () => {
             { id: 3, text: 'test', done: false },
         ]);
     });
-    test('useObservableReducer accepts lazy initializer functions', () => {
+    test('useObservableReducer accepts lazy initializer functions', async () => {
         const reducer = (state: number, action: { type: 'inc' }) => (action.type === 'inc' ? state + 1 : state);
         const lazyInit = () => 5;
 
@@ -1325,7 +1375,7 @@ describe('useObservableReducer', () => {
 
         expect(result.current[0].get()).toBe(5);
 
-        act(() => {
+        await act(async () => {
             (result.current[1] as any)({ type: 'inc' });
         });
 
@@ -1419,7 +1469,7 @@ describe('useObserve', () => {
         expect(num).toEqual(1);
         expect(numSets).toEqual(0);
     });
-    test('useObserve with undefined observable calls reaction', () => {
+    test('useObserve with undefined observable calls reaction', async () => {
         let num = 0;
         let numObserves = 0;
         const obs$ = observable<number | undefined>(undefined);
@@ -1438,14 +1488,14 @@ describe('useObserve', () => {
         expect(num).toEqual(1);
         expect(numObserves).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(1);
         expect(numObserves).toEqual(1);
     });
-    test('useObserve with a deps array', () => {
+    test('useObserve with a deps array', async () => {
         let num = 0;
         let numInner = 0;
         const obsOuter$ = observable(0);
@@ -1477,7 +1527,7 @@ describe('useObserve', () => {
         expect(lastObservedDep).toEqual(0);
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obsOuter$.set(1);
         });
 
@@ -1487,7 +1537,7 @@ describe('useObserve', () => {
         expect(lastObservedDep).toEqual(1);
 
         // If inner dep changes it should run again without rendering
-        act(() => {
+        await act(async () => {
             obsInner$.set(1);
         });
 
@@ -1497,7 +1547,7 @@ describe('useObserve', () => {
         expect(lastObservedDep).toEqual(1);
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obsOuter$.set(2);
         });
 
@@ -1524,7 +1574,7 @@ describe('useObserveEffect', () => {
 
         expect(num).toEqual(1);
     });
-    test('useObserveEffect updates with changes', () => {
+    test('useObserveEffect updates with changes', async () => {
         let num = 0;
         const state$ = observable(0);
         function Test() {
@@ -1541,17 +1591,17 @@ describe('useObserveEffect', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             state$.set((v) => v + 1);
         });
         expect(num).toEqual(2);
 
-        act(() => {
+        await act(async () => {
             state$.set((v) => v + 1);
         });
         expect(num).toEqual(3);
     });
-    test('useObserve with a deps array', () => {
+    test('useObserve with a deps array', async () => {
         let num = 0;
         let numInner = 0;
         const obsOuter$ = observable(0);
@@ -1583,7 +1633,7 @@ describe('useObserveEffect', () => {
         expect(lastObservedDep).toEqual(0);
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obsOuter$.set(1);
         });
 
@@ -1593,7 +1643,7 @@ describe('useObserveEffect', () => {
         expect(lastObservedDep).toEqual(1);
 
         // If inner dep changes it should run again without rendering
-        act(() => {
+        await act(async () => {
             obsInner$.set(1);
         });
 
@@ -1602,7 +1652,7 @@ describe('useObserveEffect', () => {
         expect(lastObserved).toEqual(1);
         expect(lastObservedDep).toEqual(1);
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obsOuter$.set(2);
         });
 
@@ -1614,7 +1664,7 @@ describe('useObserveEffect', () => {
 });
 
 describe('observer', () => {
-    test('observer basic', () => {
+    test('observer basic', async () => {
         let num = 0;
         const obs$ = observable(0);
         const Test = observer(function Test() {
@@ -1630,13 +1680,13 @@ describe('observer', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(2);
     });
-    test('observer with useSelector inside', () => {
+    test('observer with useSelector inside', async () => {
         let num = 0;
         const obs$ = observable(0);
         const Test = observer(function Test() {
@@ -1653,13 +1703,13 @@ describe('observer', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(2);
     });
-    test('useSelector renders once when it returns the same thing inside an observer', () => {
+    test('useSelector renders once when it returns the same thing inside an observer', async () => {
         const obs = observable('hi');
         let num = 0;
         let num2 = 0;
@@ -1682,12 +1732,12 @@ describe('observer', () => {
         expect(lastValue).toEqual(true);
         expect(num).toEqual(1);
         expect(num2).toEqual(1);
-        act(() => {
+        await act(async () => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
         expect(num2).toEqual(2);
-        act(() => {
+        await act(async () => {
             obs.set('hello2');
         });
         expect(num).toEqual(4);
@@ -1695,7 +1745,7 @@ describe('observer', () => {
     });
 });
 describe('useObservable', () => {
-    test('useObservable with an object', () => {
+    test('useObservable with an object', async () => {
         let num = 0;
         let obs$: Observable<{ test: number }>;
         let value = 0;
@@ -1715,14 +1765,14 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.test.set(1);
         });
 
         expect(num).toEqual(2);
         expect(value).toEqual(1);
     });
-    test('useObservable with a function', () => {
+    test('useObservable with a function', async () => {
         let num = 0;
         let obs$: Observable<{ test: number }>;
         let value = 0;
@@ -1742,14 +1792,14 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.test.set(1);
         });
 
         expect(num).toEqual(2);
         expect(value).toEqual(1);
     });
-    test('useObservable with a computed function', () => {
+    test('useObservable with a computed function', async () => {
         let num = 0;
         const obs$: Observable = observable(0);
         let value = 0;
@@ -1769,14 +1819,14 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(2);
         expect(value).toEqual(1);
     });
-    test('useObservable with a deps array', () => {
+    test('useObservable with a deps array', async () => {
         let num = 0;
         let numInner = 0;
         const obs$: Observable = observable(0);
@@ -1805,7 +1855,7 @@ describe('useObservable', () => {
 
         // If deps array changes it should refresh observable
 
-        act(() => {
+        await act(async () => {
             deps = ['hello'];
             obs$.set(1);
         });
@@ -1815,7 +1865,7 @@ describe('useObservable', () => {
         expect(value).toEqual('hello');
 
         // If deps array doesn't change it should not refresh
-        act(() => {
+        await act(async () => {
             deps = ['hello'];
             obs$.set(2);
         });
@@ -1824,7 +1874,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(2);
         expect(value).toEqual('hello');
     });
-    test('useObservable with a deps array of objects', () => {
+    test('useObservable with a deps array of objects', async () => {
         let num = 0;
         let numInner = 0;
         const obs$: Observable = observable(0);
@@ -1853,7 +1903,7 @@ describe('useObservable', () => {
 
         // If deps array changes it should refresh observable
 
-        act(() => {
+        await act(async () => {
             deps = [{ text: 'hello' }];
             obs$.set(1);
         });
@@ -1863,7 +1913,7 @@ describe('useObservable', () => {
         expect(value).toEqual({ text: 'hello' });
 
         // If deps array doesn't change it should not refresh
-        act(() => {
+        await act(async () => {
             deps = [{ text: 'hello' }];
             obs$.set(2);
         });
@@ -1872,7 +1922,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(2);
         expect(value).toEqual({ text: 'hello' });
     });
-    test('useObservable with a lookup table and empty deps array', () => {
+    test('useObservable with a lookup table and empty deps array', async () => {
         let num = 0;
         let numInner = 0;
         const obs$: Observable = observable(0);
@@ -1898,7 +1948,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(1);
         expect(value).toEqual('a0');
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
@@ -1906,7 +1956,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(2);
         expect(value).toEqual('a1');
 
-        act(() => {
+        await act(async () => {
             obs$.set(2);
         });
 
@@ -1914,7 +1964,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(3);
         expect(value).toEqual('a2');
     });
-    test('useComputed with a deps array', () => {
+    test('useComputed with a deps array', async () => {
         let num = 0;
         const obs$: Observable = observable(0);
         let value: string = '';
@@ -1946,7 +1996,7 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual('hi');
 
-        act(() => {
+        await act(async () => {
             deps = ['hello'];
             obs$.set(1);
         });
@@ -1954,7 +2004,7 @@ describe('useObservable', () => {
         expect(num).toEqual(2);
         expect(value).toEqual('hello');
 
-        act(() => {
+        await act(async () => {
             deps = ['hello2'];
             obs$.set(2);
         });
@@ -1962,13 +2012,13 @@ describe('useObservable', () => {
         expect(num).toEqual(3);
         expect(value).toEqual('hello2');
 
-        act(() => {
+        await act(async () => {
             obsLocal$!.set('test');
         });
 
         expect(setTo).toEqual('test');
     });
-    test('useComputed vs observable deep object set', () => {
+    test('useComputed vs observable deep object set', async () => {
         // From: https://github.com/LegendApp/legend-state/issues/305
         const o$ = observable([{ hotspot: { position: { x: 0 } } }]);
         let numRenders = 0;
@@ -2001,21 +2051,21 @@ describe('useObservable', () => {
 
         expect(lastValue).toEqual([{ hotspot: { position: { x: 0 } } }]);
 
-        act(() => {
+        await act(async () => {
             o$[0].hotspot.position.x.set(2);
         });
 
         expect(numRenders).toEqual(2);
         expect(lastValue).toEqual([{ hotspot: { position: { x: 2 } } }]);
 
-        act(() => {
+        await act(async () => {
             o$.set([{ hotspot: { position: { x: 1 } } }]);
         });
 
         expect(numRenders).toEqual(3);
         expect(lastValue).toEqual([{ hotspot: { position: { x: 1 } } }]);
 
-        act(() => {
+        await act(async () => {
             o$[0].hotspot.position.x.set(3);
         });
 
@@ -2058,7 +2108,7 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(1 + '_' + originalRand);
 
-        act(() => {
+        await act(async () => {
             obs2$.set(1);
         });
 
@@ -2103,7 +2153,7 @@ describe('useObservable', () => {
         expect(innerDerivedCallCount).toBe(1);
 
         // Unmount the component
-        act(() => {
+        await act(async () => {
             unmount();
         });
 
@@ -2114,13 +2164,13 @@ describe('useObservable', () => {
         const innerDerivedCountAfterUnmount = innerDerivedCallCount;
 
         // Change outer$ multiple times after unmount
-        act(() => {
+        await act(async () => {
             outer$.set(false);
         });
-        act(() => {
+        await act(async () => {
             outer$.set(true);
         });
-        act(() => {
+        await act(async () => {
             outer$.set(false);
         });
 
@@ -2192,7 +2242,7 @@ describe('useObservable', () => {
     });
 });
 describe('useObservableState', () => {
-    test('useObservableState does not select if value not accessed', () => {
+    test('useObservableState does not select if value not accessed', async () => {
         let num = 0;
         let obs$: Observable<number>;
         const Test = function Test() {
@@ -2210,13 +2260,13 @@ describe('useObservableState', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(num).toEqual(1);
     });
-    test('useObservableState select if value accessed', () => {
+    test('useObservableState select if value accessed', async () => {
         let num = 0;
         let obs$: Observable<number>;
         let value = 0;
@@ -2237,7 +2287,7 @@ describe('useObservableState', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
@@ -2246,7 +2296,7 @@ describe('useObservableState', () => {
     });
 });
 describe('Reactive', () => {
-    test('Reactive div $className', () => {
+    test('Reactive div $className', async () => {
         const obs$ = observable('hi');
         let num = 0;
         const Test = function Test() {
@@ -2269,7 +2319,7 @@ describe('Reactive', () => {
         expect(items.length).toEqual(1);
         expect(items[0].className).toEqual('hi');
 
-        act(() => {
+        await act(async () => {
             obs$.set('hello');
         });
 
@@ -2284,7 +2334,7 @@ describe('Reactive', () => {
 });
 
 describe('Memo', () => {
-    test('Memo works with function returning function', () => {
+    test('Memo works with function returning function', async () => {
         let num = 0;
         let obs$: Observable<boolean>;
         function A() {
@@ -2310,7 +2360,7 @@ describe('Memo', () => {
 
         expect(num).toEqual(1);
 
-        act(() => {
+        await act(async () => {
             obs$.set(false);
         });
 
@@ -2319,7 +2369,7 @@ describe('Memo', () => {
         items = container.querySelectorAll('div');
         expect(items[0].textContent).toEqual('BB');
     });
-    test('Memo works with a string', () => {
+    test('Memo works with a string', async () => {
         const obs$ = observable({ test: 'hi' });
         const Test = function Test() {
             return (
@@ -2335,7 +2385,7 @@ describe('Memo', () => {
 
         expect(items[0].textContent).toEqual('hi');
 
-        act(() => {
+        await act(async () => {
             obs$.test.set('hello');
         });
 
@@ -2391,7 +2441,7 @@ describe('tracing', () => {
         // Restore console.log after each test
         (console.log as jest.Mock).mockRestore();
     });
-    test('useTraceListeners', () => {
+    test('useTraceListeners', async () => {
         const obs$ = observable(0);
         const Test = observer(function Test() {
             useTraceListeners();
@@ -2404,14 +2454,14 @@ describe('tracing', () => {
 1: `);
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
         expect(console.log).toHaveBeenCalledWith(`[legend-state] tracking 1 observable:
 1: `);
     });
-    test('useTraceUpdates', () => {
+    test('useTraceUpdates', async () => {
         const obs$ = observable(0);
         const Test = observer(function Test() {
             useTraceUpdates();
@@ -2421,7 +2471,7 @@ describe('tracing', () => {
         render(createElement(Test));
 
         // If deps array changes it should refresh observable
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -25,6 +25,7 @@ import { useTraceListeners } from '../src/trace/useTraceListeners';
 import { useTraceUpdates } from '../src/trace/useTraceUpdates';
 import { $React } from '@legendapp/state/react-web';
 import { syncObservable } from '../sync';
+import { createObservableHook } from '../src/react-hooks/createObservableHook';
 
 type TestObject = { id: string; label: string };
 
@@ -32,8 +33,24 @@ if (typeof document === 'undefined') {
     GlobalRegistrator.register();
 }
 
+async function captureConsoleErrors(fn: () => void | Promise<void>) {
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: any[]) => {
+        errors.push(args.map(String).join(' '));
+    };
+
+    try {
+        await fn();
+    } finally {
+        console.error = originalError;
+    }
+
+    return errors;
+}
+
 describe('useSelector', () => {
-    test('useSelector basics', async () => {
+    test('useSelector basics', () => {
         const obs = observable('hi');
         let num = 0;
         const { result } = renderHook(() => {
@@ -44,43 +61,43 @@ describe('useSelector', () => {
         });
 
         expect(num).toEqual(1);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
         expect(result.current).toEqual('hello there');
-        await act(async () => {
+        act(() => {
             obs.set('z');
         });
         expect(num).toEqual(5);
         expect(result.current).toEqual('z there');
     });
-    test('useSelector with observable', async () => {
+    test('useSelector with observable', () => {
         const obs = observable('hi');
         const { result } = renderHook(() => {
             return useSelector(() => obs.get());
         });
 
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(result.current).toEqual('hello');
-        await act(async () => {
+        act(() => {
             obs.set('z');
         });
         expect(result.current).toEqual('z');
     });
-    test('useSelector with computed', async () => {
+    test('useSelector with computed', () => {
         const obs = observable({ value: 'hi', computed: () => obs.value.get() + ' there' });
         const { result } = renderHook(() => {
             return useSelector(obs.computed);
         });
 
-        await act(async () => {
+        act(() => {
             obs.value.set('hello');
         });
         expect(result.current).toEqual('hello there');
-        await act(async () => {
+        act(() => {
             obs.value.set('z');
         });
         expect(result.current).toEqual('z there');
@@ -92,7 +109,7 @@ describe('useSelector', () => {
 
         expect(result.current).toEqual(undefined);
     });
-    test('useSelector setting twice', async () => {
+    test('useSelector setting twice', () => {
         const obs = observable('hi');
         let num = 0;
         const { result } = renderHook(() => {
@@ -104,19 +121,19 @@ describe('useSelector', () => {
 
         expect(num).toEqual(1);
         expect(result.current).toEqual('hi there');
-        await act(async () => {
+        act(() => {
             obs.set('hello');
             obs.set('hello2');
         });
         expect(num).toEqual(4); // Once for each set plus the render
         expect(result.current).toEqual('hello2 there');
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(6); // Once for set plus render
         expect(result.current).toEqual('hello there');
     });
-    test('useSelector two observables', async () => {
+    test('useSelector two observables', () => {
         const obs = observable('hi');
         const obs2 = observable('hello');
         let num = 0;
@@ -129,7 +146,7 @@ describe('useSelector', () => {
 
         expect(num).toEqual(1);
         expect(result.current).toEqual('hi hello there');
-        await act(async () => {
+        act(() => {
             obs.set('aa');
             obs.set('a');
             obs2.set('bb');
@@ -137,18 +154,18 @@ describe('useSelector', () => {
         });
         expect(num).toEqual(6);
         expect(result.current).toEqual('a b there');
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(8);
         expect(result.current).toEqual('hello b there');
-        await act(async () => {
+        act(() => {
             obs2.set('z');
         });
         expect(num).toEqual(10);
         expect(result.current).toEqual('hello z there');
     });
-    test('useSelector cleaned up', async () => {
+    test('useSelector cleaned up', () => {
         const obs = observable('hi');
         let num = 0;
         const { result, unmount } = renderHook(() => {
@@ -163,7 +180,7 @@ describe('useSelector', () => {
 
         unmount();
 
-        await act(async () => {
+        act(() => {
             obs.set('a');
         });
         // Set after unmounted triggers the observe but since it does not
@@ -171,13 +188,13 @@ describe('useSelector', () => {
         expect(num).toEqual(1);
         expect(result.current).toEqual('hi there');
 
-        await act(async () => {
+        act(() => {
             obs.set('b');
         });
 
         expect(num).toEqual(1);
     });
-    test('useSelector with forceRender', async () => {
+    test('useSelector with forceRender', () => {
         const obs = observable('hi');
         let num = 0;
         let numSelects = 0;
@@ -194,7 +211,7 @@ describe('useSelector', () => {
         }
         render(createElement(Test));
 
-        await act(async () => {
+        act(() => {
             fr();
             fr();
             obs.set('hello1');
@@ -207,7 +224,7 @@ describe('useSelector', () => {
         expect(num).toEqual(3);
         expect(numSelects).toEqual(6);
 
-        await act(async () => {
+        act(() => {
             fr();
             fr();
             obs.set('hello2');
@@ -220,7 +237,7 @@ describe('useSelector', () => {
         expect(num).toEqual(5);
         expect(numSelects).toEqual(11);
     });
-    test('useSelector runs once in non-strict mode', async () => {
+    test('useSelector runs once in non-strict mode', () => {
         const obs = observable('hi');
 
         let num = 0;
@@ -234,12 +251,12 @@ describe('useSelector', () => {
         render(createElement(Test));
 
         expect(num).toEqual(1);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
     });
-    test('useSelector runs twice in strict mode', async () => {
+    test('useSelector runs twice in strict mode', () => {
         const obs = observable('hi');
 
         let num = 0;
@@ -256,12 +273,12 @@ describe('useSelector', () => {
         render(createElement(App));
 
         expect(num).toEqual(2);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(6);
     });
-    test('Renders once with one selector listening to multiple', async () => {
+    test('Renders once with one selector listening to multiple', () => {
         const obs = observable('hi');
         const obs2 = observable('hi');
         const obs3 = observable('hi');
@@ -277,12 +294,12 @@ describe('useSelector', () => {
         render(createElement(Test));
 
         expect(num).toEqual(1);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
     });
-    test('Renders once for each selector', async () => {
+    test('Renders once for each selector', () => {
         const obs = observable('hi');
         const obs2 = observable('hi');
         const obs3 = observable('hi');
@@ -306,13 +323,13 @@ describe('useSelector', () => {
         render(createElement(Test));
 
         expect(num).toEqual(3);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         // Goes up by two because it runs, decides to re-render, and runs again
         expect(num).toEqual(7);
     });
-    test('useSelector renders once when set to the same thing', async () => {
+    test('useSelector renders once when set to the same thing', () => {
         const obs = observable('hi');
         let num = 0;
         renderHook(() => {
@@ -323,20 +340,20 @@ describe('useSelector', () => {
         });
 
         expect(num).toEqual(1);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(3); // Doesn't re-run the selector so it's not different
-        await act(async () => {
+        act(() => {
             obs.set('hi');
         });
         expect(num).toEqual(5);
     });
-    test('useSelector renders once when it returns the same thing', async () => {
+    test('useSelector renders once when it returns the same thing', () => {
         const obs = observable('hi');
         let num = 0;
         let num2 = 0;
@@ -359,18 +376,18 @@ describe('useSelector', () => {
         expect(lastValue).toEqual(true);
         expect(num).toEqual(1);
         expect(num2).toEqual(1);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
         expect(num2).toEqual(2);
-        await act(async () => {
+        act(() => {
             obs.set('hello2');
         });
         expect(num).toEqual(4);
         expect(num2).toEqual(2);
     });
-    test('useSelector with changing nodes', async () => {
+    test('useSelector with changing nodes', () => {
         const obs1$ = observable(false);
         const obs2$ = observable(false);
         let lastValue = false;
@@ -387,16 +404,16 @@ describe('useSelector', () => {
         render(createElement(App));
 
         expect(lastValue).toEqual(true);
-        await act(async () => {
+        act(() => {
             obs1$.set(true);
         });
         expect(lastValue).toEqual(true);
-        await act(async () => {
+        act(() => {
             obs2$.set(true);
         });
         expect(lastValue).toEqual(false);
     });
-    test('useSelector listener count strict', async () => {
+    test('useSelector listener count strict', () => {
         const obs = observable('hi');
         let num = 0;
         const numListeners = () => getNode(obs).listeners?.size;
@@ -415,23 +432,23 @@ describe('useSelector', () => {
 
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(2);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(4);
-        await act(async () => {
+        act(() => {
             obs.set('z');
         });
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(6);
-        await act(async () => {
+        act(() => {
             obs.set('q');
         });
         expect(numListeners()).toEqual(2);
         expect(num).toEqual(8);
     });
-    test('useSelector listener count', async () => {
+    test('useSelector listener count', () => {
         const obs = observable('hi');
         let num = 0;
         const numListeners = () => getNode(obs).listeners?.size;
@@ -450,23 +467,23 @@ describe('useSelector', () => {
 
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(1);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(2);
-        await act(async () => {
+        act(() => {
             obs.set('z');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(3);
-        await act(async () => {
+        act(() => {
             obs.set('q');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(4);
     });
-    test('useSelector for pure proxy use', async () => {
+    test('useSelector for pure proxy use', () => {
         const obs = observable('hi');
         let num = 0;
         const numListeners = () => getNode(obs).listeners?.size;
@@ -483,17 +500,17 @@ describe('useSelector', () => {
 
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(1);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(2);
-        await act(async () => {
+        act(() => {
             obs.set('z');
         });
         expect(numListeners()).toEqual(1);
         expect(num).toEqual(3);
-        await act(async () => {
+        act(() => {
             obs.set('q');
         });
         expect(numListeners()).toEqual(1);
@@ -582,21 +599,21 @@ describe('useSelector', () => {
             render(createElement(App));
 
             expect(lastValue).toEqual(1);
-            await act(async () => {
+            act(() => {
                 obs$.todos.push(1);
             });
             expect(lastValue).toEqual(2);
-            await act(async () => {
+            act(() => {
                 obs$.todos.splice(0, 1);
             });
             expect(lastValue).toEqual(1);
-            await act(async () => {
+            act(() => {
                 obs$.todos.set([]);
             });
             expect(lastValue).toEqual(0);
         });
     });
-    test('use$ with array length', async () => {
+    test('use$ with array length', () => {
         async () => {
             const obs$ = observable<{ test: number[] }>({
                 test: [0],
@@ -614,96 +631,122 @@ describe('useSelector', () => {
             render(createElement(App));
 
             expect(lastValue).toEqual([0]);
-            await act(async () => {
+            act(() => {
                 obs$.assign({ test: [1] });
             });
             expect(lastValue).toEqual([1]);
-            await act(async () => {
+            act(() => {
                 obs$.assign({ test: [1, 2, 3] });
             });
             expect(lastValue).toEqual([1, 2, 3]);
-            await act(async () => {
+            act(() => {
                 obs$.assign({ test: [] });
             });
             expect(lastValue).toEqual([]);
         };
     });
+    test('useSelector notifies synchronously outside render', () => {
+        const obs = observable('hi');
+        const { result } = renderHook(() => useSelector(obs));
 
-    test('useSelector does not warn "Cannot update a component" with useObserve', async () => {
-        const errors: string[] = [];
-        const originalError = console.error;
-        console.error = (...args: any[]) => {
-            errors.push(args.map(String).join(' '));
-        };
-
-        try {
+        expect(result.current).toEqual('hi');
+        act(() => {
+            obs.set('hello');
+        });
+        expect(result.current).toEqual('hello');
+    });
+    test('useSelector defers useObserve render updates', async () => {
+        const errors = await captureConsoleErrors(async () => {
             const sideEffect$ = observable(0);
             const showTrigger$ = observable(false);
 
-            let sideEffectValue: number | undefined = undefined;
+            let sideEffectValue: number | undefined;
             const CompB = function CompB() {
                 sideEffectValue = useSelector(sideEffect$);
                 return createElement('div', undefined, sideEffectValue);
             };
 
-            // CompTrigger has a useObserve that, when evaluated during render, sets sideEffect$.
-            let triggerRenderCount = 0;
             const CompTrigger = function CompTrigger() {
-                triggerRenderCount++;
-
                 useObserve(() => {
-                    sideEffect$.set(triggerRenderCount * 10);
-                    return triggerRenderCount;
+                    sideEffect$.set(10);
                 });
                 return createElement('div', undefined);
             };
 
-            // Conditionally render CompTrigger so CompB is already subscribed when it mounts.
             const App = function App() {
                 const show = useSelector(showTrigger$);
                 return createElement('div', undefined, createElement(CompB), show ? createElement(CompTrigger) : null);
             };
 
-            // Mount with only CompB — it subscribes to sideEffect$.
             render(createElement(App));
             expect(sideEffectValue).toEqual(0);
 
-            // Now mount CompTrigger — its selector runs during render and sets sideEffect$.
             await act(async () => {
                 showTrigger$.set(true);
             });
             await promiseTimeout(0);
+
             expect(sideEffectValue).toEqual(10);
+        });
 
-            const midRenderWarning = errors.find((e) => e.includes('Cannot update a component'));
-            expect(midRenderWarning).toBeUndefined();
-        } finally {
-            console.error = originalError;
-        }
+        expect(errors).toEqual([]);
     });
-    test('useSelector does not warn "Cannot update a component" with plain component .set()', async () => {
-        const errors: string[] = [];
-        const originalError = console.error;
-        console.error = (...args: any[]) => {
-            errors.push(args.map(String).join(' '));
-        };
-
-        try {
+    test('useSelector defers useObservable dependency render updates', async () => {
+        const errors = await captureConsoleErrors(async () => {
             const sideEffect$ = observable(0);
-            const showTrigger$ = observable(false);
+            const trigger$ = observable(0);
 
-            let sideEffectValue: number | undefined = undefined;
+            let sideEffectValue: number | undefined;
             const CompB = function CompB() {
                 sideEffectValue = useSelector(sideEffect$);
                 return createElement('div', undefined, sideEffectValue);
             };
 
-            // CompTrigger is a plain component that calls .set() in its render body.
-            // No observer, no useSelector, no useObserve.
-            let triggerRenderCount = 0;
+            const CompTrigger = function CompTrigger({ value }: { value: number }) {
+                const local$ = useObservable(() => {
+                    sideEffect$.set(value);
+                    return value;
+                }, [value]);
+                useSelector(local$);
+                return createElement('div', undefined);
+            };
+
+            const App = function App() {
+                const value = useSelector(trigger$);
+                return createElement('div', undefined, createElement(CompB), createElement(CompTrigger, { value }));
+            };
+
+            render(createElement(App));
+            expect(sideEffectValue).toEqual(0);
+
+            await act(async () => {
+                trigger$.set(1);
+            });
+            await promiseTimeout(0);
+
+            expect(sideEffectValue).toEqual(1);
+        });
+
+        expect(errors).toEqual([]);
+    });
+    test('useSelector defers createObservableHook render updates', async () => {
+        const errors = await captureConsoleErrors(async () => {
+            const sideEffect$ = observable(0);
+            const showTrigger$ = observable(false);
+            const useTestHook = createObservableHook((value: number) => {
+                React.useState(value);
+                sideEffect$.set(value);
+                return value;
+            });
+
+            let sideEffectValue: number | undefined;
+            const CompB = function CompB() {
+                sideEffectValue = useSelector(sideEffect$);
+                return createElement('div', undefined, sideEffectValue);
+            };
+
             const CompTrigger = function CompTrigger() {
-                triggerRenderCount++;
-                sideEffect$.set(triggerRenderCount * 10);
+                useTestHook(10);
                 return createElement('div', undefined);
             };
 
@@ -719,13 +762,86 @@ describe('useSelector', () => {
                 showTrigger$.set(true);
             });
             await promiseTimeout(0);
-            expect(sideEffectValue).toEqual(10);
 
-            const midRenderWarning = errors.find((e) => e.includes('Cannot update a component'));
-            expect(midRenderWarning).toBeUndefined();
-        } finally {
-            console.error = originalError;
-        }
+            expect(sideEffectValue).toEqual(10);
+        });
+
+        expect(errors).toEqual([]);
+    });
+    test('useSelector coalesces Legend-owned render updates', async () => {
+        const sideEffect$ = observable(0);
+        const showTrigger$ = observable(false);
+
+        let sideEffectValue: number | undefined;
+        let sideEffectRenderCount = 0;
+        const CompB = React.memo(function CompB() {
+            sideEffectRenderCount++;
+            sideEffectValue = useSelector(sideEffect$);
+            return createElement('div', undefined, sideEffectValue);
+        });
+
+        const CompTrigger = function CompTrigger() {
+            useObserve(() => {
+                sideEffect$.set(10);
+                sideEffect$.set(20);
+                sideEffect$.set(30);
+            });
+            return createElement('div', undefined);
+        };
+
+        const App = function App() {
+            const show = useSelector(showTrigger$);
+            return createElement('div', undefined, createElement(CompB), show ? createElement(CompTrigger) : null);
+        };
+
+        render(createElement(App));
+        expect(sideEffectValue).toEqual(0);
+        expect(sideEffectRenderCount).toEqual(1);
+
+        await act(async () => {
+            showTrigger$.set(true);
+        });
+        await promiseTimeout(0);
+
+        expect(sideEffectValue).toEqual(30);
+        expect(sideEffectRenderCount).toEqual(2);
+    });
+    test('useSelector ignores deferred render update after unsubscribe', async () => {
+        const errors = await captureConsoleErrors(async () => {
+            const sideEffect$ = observable(0);
+            const showTrigger$ = observable(false);
+
+            let sideEffectRenderCount = 0;
+            const CompB = function CompB() {
+                sideEffectRenderCount++;
+                useSelector(sideEffect$);
+                return createElement('div', undefined);
+            };
+
+            const CompTrigger = function CompTrigger() {
+                useObserve(() => {
+                    sideEffect$.set(1);
+                });
+                return createElement('div', undefined);
+            };
+
+            const App = function App() {
+                const show = useSelector(showTrigger$);
+                return createElement('div', undefined, show ? createElement(CompTrigger) : createElement(CompB));
+            };
+
+            render(createElement(App));
+            expect(sideEffectRenderCount).toEqual(1);
+
+            await act(async () => {
+                showTrigger$.set(true);
+            });
+            await promiseTimeout(0);
+
+            expect(sideEffectRenderCount).toEqual(1);
+        });
+
+        expect(errors).toEqual([]);
     });
 });
 
@@ -751,7 +867,7 @@ describe('For', () => {
         let items = container.querySelectorAll('li');
         expect(items.length).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             obs.items.splice(0, 0, { id: 1, label: '1' });
         });
 
@@ -759,7 +875,7 @@ describe('For', () => {
         expect(items.length).toEqual(2);
         expect(items[0].id).toEqual('1');
     });
-    test('Array insert has stable reference 2', async () => {
+    test('Array insert has stable reference 2', () => {
         const obs = observable({
             items: [
                 { id: 'B', label: 'B' },
@@ -782,7 +898,7 @@ describe('For', () => {
         let items = container.querySelectorAll('li');
         expect(items.length).toEqual(2);
 
-        await act(async () => {
+        act(() => {
             obs.items.splice(0, 0, { id: 'C', label: 'C' } as TestObject);
         });
 
@@ -792,7 +908,7 @@ describe('For', () => {
         expect(items[1].id).toEqual('B');
         expect(items[2].id).toEqual('A');
 
-        await act(async () => {
+        act(() => {
             obs.items.splice(0, 0, { id: 'D', label: 'D' });
         });
 
@@ -853,7 +969,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('B');
         expect(items[1].id).toEqual('A');
     });
-    test('For with Map optimized', async () => {
+    test('For with Map optimized', () => {
         const obs = observable({
             items: new Map<string, TestObject>([['m2', { label: 'B', id: 'B' }]]),
         });
@@ -874,7 +990,7 @@ describe('For', () => {
         expect(items.length).toEqual(1);
         expect(items[0].id).toEqual('B');
 
-        await act(async () => {
+        act(() => {
             obs.items.set('m1', { label: 'A', id: 'A' });
         });
 
@@ -912,7 +1028,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('A');
         expect(items[1].id).toEqual('B');
     });
-    test('For with object and deleted', async () => {
+    test('For with object and deleted', () => {
         const obs = observable({
             items: {
                 m2: { label: 'B', id: 'B' },
@@ -937,7 +1053,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('B');
         expect(items[1].id).toEqual('A');
 
-        await act(async () => {
+        act(() => {
             obs.items.m2.delete();
         });
 
@@ -987,7 +1103,7 @@ describe('For', () => {
         expect(items[0].id).toEqual('B');
         expect(items[1].id).toEqual('A');
     });
-    test('Push, clear, push in For optimized', async () => {
+    test('Push, clear, push in For optimized', () => {
         interface ValObject {
             val: number;
         }
@@ -1013,14 +1129,14 @@ describe('For', () => {
         let items = container.querySelectorAll('li');
         expect(items.length).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             clear();
         });
 
         items = container.querySelectorAll('li');
         expect(items.length).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             push();
         });
 
@@ -1046,7 +1162,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs.ok.set(true);
         });
 
@@ -1095,7 +1211,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs.ok.set(true);
         });
 
@@ -1110,7 +1226,7 @@ describe('Show', () => {
         expect(items.length).toEqual(1);
         expect(items[0].textContent).toEqual('hi 0');
 
-        await act(async () => {
+        act(() => {
             obs.ok.set(false);
         });
 
@@ -1122,7 +1238,7 @@ describe('Show', () => {
         items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs.ok.set(true);
         });
 
@@ -1152,7 +1268,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs.value.set('test');
         });
 
@@ -1179,31 +1295,31 @@ describe('Show', () => {
         }
         render(createElement(Test));
 
-        await act(async () => {
+        act(() => {
             obs.value.set('test');
         });
 
         expect(numRenders).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             obs.value.set('test2');
         });
 
         expect(numRenders).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             obs.value.delete();
         });
 
         expect(numRenders).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             obs.value.set('test');
         });
 
         expect(numRenders).toEqual(2);
 
-        await act(async () => {
+        act(() => {
             obs.value.set('test2');
         });
 
@@ -1230,7 +1346,7 @@ describe('Show', () => {
         let items = container.querySelectorAll('span');
         expect(items.length).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs.ok.set(true);
         });
 
@@ -1239,7 +1355,7 @@ describe('Show', () => {
         expect(items[0].textContent).toEqual('hi');
         expect(testValue).toEqual('tester');
     });
-    test('useSelector reconfigures when options change', async () => {
+    test('useSelector reconfigures when options change', () => {
         const obs = observable(0);
         let runCount = 0;
 
@@ -1257,7 +1373,7 @@ describe('Show', () => {
 
         expect(runCount).toBe(1);
 
-        await act(async () => {
+        act(() => {
             obs.set(1);
         });
 
@@ -1267,7 +1383,7 @@ describe('Show', () => {
         const countAfterOptionChange = runCount;
         expect(countAfterOptionChange).toBe(4);
 
-        await act(async () => {
+        act(() => {
             obs.set(1);
         });
 
@@ -1364,7 +1480,7 @@ describe('useObservableReducer', () => {
             { id: 3, text: 'test', done: false },
         ]);
     });
-    test('useObservableReducer accepts lazy initializer functions', async () => {
+    test('useObservableReducer accepts lazy initializer functions', () => {
         const reducer = (state: number, action: { type: 'inc' }) => (action.type === 'inc' ? state + 1 : state);
         const lazyInit = () => 5;
 
@@ -1372,7 +1488,7 @@ describe('useObservableReducer', () => {
 
         expect(result.current[0].get()).toBe(5);
 
-        await act(async () => {
+        act(() => {
             (result.current[1] as any)({ type: 'inc' });
         });
 
@@ -1466,7 +1582,7 @@ describe('useObserve', () => {
         expect(num).toEqual(1);
         expect(numSets).toEqual(0);
     });
-    test('useObserve with undefined observable calls reaction', async () => {
+    test('useObserve with undefined observable calls reaction', () => {
         let num = 0;
         let numObserves = 0;
         const obs$ = observable<number | undefined>(undefined);
@@ -1485,14 +1601,14 @@ describe('useObserve', () => {
         expect(num).toEqual(1);
         expect(numObserves).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs$.set(1);
         });
 
         expect(num).toEqual(1);
         expect(numObserves).toEqual(1);
     });
-    test('useObserve with a deps array', async () => {
+    test('useObserve with a deps array', () => {
         let num = 0;
         let numInner = 0;
         const obsOuter$ = observable(0);
@@ -1524,7 +1640,7 @@ describe('useObserve', () => {
         expect(lastObservedDep).toEqual(0);
 
         // If deps array changes it should refresh observable
-        await act(async () => {
+        act(() => {
             obsOuter$.set(1);
         });
 
@@ -1534,7 +1650,7 @@ describe('useObserve', () => {
         expect(lastObservedDep).toEqual(1);
 
         // If inner dep changes it should run again without rendering
-        await act(async () => {
+        act(() => {
             obsInner$.set(1);
         });
 
@@ -1544,7 +1660,7 @@ describe('useObserve', () => {
         expect(lastObservedDep).toEqual(1);
 
         // If deps array changes it should refresh observable
-        await act(async () => {
+        act(() => {
             obsOuter$.set(2);
         });
 
@@ -1571,7 +1687,7 @@ describe('useObserveEffect', () => {
 
         expect(num).toEqual(1);
     });
-    test('useObserveEffect updates with changes', async () => {
+    test('useObserveEffect updates with changes', () => {
         let num = 0;
         const state$ = observable(0);
         function Test() {
@@ -1588,17 +1704,17 @@ describe('useObserveEffect', () => {
 
         expect(num).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             state$.set((v) => v + 1);
         });
         expect(num).toEqual(2);
 
-        await act(async () => {
+        act(() => {
             state$.set((v) => v + 1);
         });
         expect(num).toEqual(3);
     });
-    test('useObserve with a deps array', async () => {
+    test('useObserve with a deps array', () => {
         let num = 0;
         let numInner = 0;
         const obsOuter$ = observable(0);
@@ -1630,7 +1746,7 @@ describe('useObserveEffect', () => {
         expect(lastObservedDep).toEqual(0);
 
         // If deps array changes it should refresh observable
-        await act(async () => {
+        act(() => {
             obsOuter$.set(1);
         });
 
@@ -1640,7 +1756,7 @@ describe('useObserveEffect', () => {
         expect(lastObservedDep).toEqual(1);
 
         // If inner dep changes it should run again without rendering
-        await act(async () => {
+        act(() => {
             obsInner$.set(1);
         });
 
@@ -1649,7 +1765,7 @@ describe('useObserveEffect', () => {
         expect(lastObserved).toEqual(1);
         expect(lastObservedDep).toEqual(1);
         // If deps array changes it should refresh observable
-        await act(async () => {
+        act(() => {
             obsOuter$.set(2);
         });
 
@@ -1658,10 +1774,49 @@ describe('useObserveEffect', () => {
         expect(lastObserved).toEqual(1);
         expect(lastObservedDep).toEqual(2);
     });
+    test('useObserveEffect defers dependency render updates', async () => {
+        const errors = await captureConsoleErrors(async () => {
+            const sideEffect$ = observable(0);
+            const trigger$ = observable(0);
+
+            let sideEffectValue: number | undefined;
+            const CompB = function CompB() {
+                sideEffectValue = useSelector(sideEffect$);
+                return createElement('div', undefined, sideEffectValue);
+            };
+
+            const CompTrigger = function CompTrigger({ value }: { value: number }) {
+                useObserveEffect(
+                    () => {
+                        sideEffect$.set(value);
+                    },
+                    [value],
+                );
+                return createElement('div', undefined);
+            };
+
+            const App = function App() {
+                const value = useSelector(trigger$);
+                return createElement('div', undefined, createElement(CompB), createElement(CompTrigger, { value }));
+            };
+
+            render(createElement(App));
+            expect(sideEffectValue).toEqual(0);
+
+            await act(async () => {
+                trigger$.set(1);
+            });
+            await promiseTimeout(0);
+
+            expect(sideEffectValue).toEqual(1);
+        });
+
+        expect(errors).toEqual([]);
+    });
 });
 
 describe('observer', () => {
-    test('observer basic', async () => {
+    test('observer basic', () => {
         let num = 0;
         const obs$ = observable(0);
         const Test = observer(function Test() {
@@ -1677,13 +1832,13 @@ describe('observer', () => {
 
         expect(num).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             obs$.set(1);
         });
 
         expect(num).toEqual(2);
     });
-    test('observer with useSelector inside', async () => {
+    test('observer with useSelector inside', () => {
         let num = 0;
         const obs$ = observable(0);
         const Test = observer(function Test() {
@@ -1700,13 +1855,13 @@ describe('observer', () => {
 
         expect(num).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             obs$.set(1);
         });
 
         expect(num).toEqual(2);
     });
-    test('useSelector renders once when it returns the same thing inside an observer', async () => {
+    test('useSelector renders once when it returns the same thing inside an observer', () => {
         const obs = observable('hi');
         let num = 0;
         let num2 = 0;
@@ -1729,12 +1884,12 @@ describe('observer', () => {
         expect(lastValue).toEqual(true);
         expect(num).toEqual(1);
         expect(num2).toEqual(1);
-        await act(async () => {
+        act(() => {
             obs.set('hello');
         });
         expect(num).toEqual(3);
         expect(num2).toEqual(2);
-        await act(async () => {
+        act(() => {
             obs.set('hello2');
         });
         expect(num).toEqual(4);
@@ -1742,7 +1897,7 @@ describe('observer', () => {
     });
 });
 describe('useObservable', () => {
-    test('useObservable with an object', async () => {
+    test('useObservable with an object', () => {
         let num = 0;
         let obs$: Observable<{ test: number }>;
         let value = 0;
@@ -1762,14 +1917,14 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs$.test.set(1);
         });
 
         expect(num).toEqual(2);
         expect(value).toEqual(1);
     });
-    test('useObservable with a function', async () => {
+    test('useObservable with a function', () => {
         let num = 0;
         let obs$: Observable<{ test: number }>;
         let value = 0;
@@ -1789,14 +1944,14 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs$.test.set(1);
         });
 
         expect(num).toEqual(2);
         expect(value).toEqual(1);
     });
-    test('useObservable with a computed function', async () => {
+    test('useObservable with a computed function', () => {
         let num = 0;
         const obs$: Observable = observable(0);
         let value = 0;
@@ -1816,14 +1971,14 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs$.set(1);
         });
 
         expect(num).toEqual(2);
         expect(value).toEqual(1);
     });
-    test('useObservable with a deps array', async () => {
+    test('useObservable with a deps array', () => {
         let num = 0;
         let numInner = 0;
         const obs$: Observable = observable(0);
@@ -1852,7 +2007,7 @@ describe('useObservable', () => {
 
         // If deps array changes it should refresh observable
 
-        await act(async () => {
+        act(() => {
             deps = ['hello'];
             obs$.set(1);
         });
@@ -1862,7 +2017,7 @@ describe('useObservable', () => {
         expect(value).toEqual('hello');
 
         // If deps array doesn't change it should not refresh
-        await act(async () => {
+        act(() => {
             deps = ['hello'];
             obs$.set(2);
         });
@@ -1871,7 +2026,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(2);
         expect(value).toEqual('hello');
     });
-    test('useObservable with a deps array of objects', async () => {
+    test('useObservable with a deps array of objects', () => {
         let num = 0;
         let numInner = 0;
         const obs$: Observable = observable(0);
@@ -1900,7 +2055,7 @@ describe('useObservable', () => {
 
         // If deps array changes it should refresh observable
 
-        await act(async () => {
+        act(() => {
             deps = [{ text: 'hello' }];
             obs$.set(1);
         });
@@ -1910,7 +2065,7 @@ describe('useObservable', () => {
         expect(value).toEqual({ text: 'hello' });
 
         // If deps array doesn't change it should not refresh
-        await act(async () => {
+        act(() => {
             deps = [{ text: 'hello' }];
             obs$.set(2);
         });
@@ -1919,7 +2074,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(2);
         expect(value).toEqual({ text: 'hello' });
     });
-    test('useObservable with a lookup table and empty deps array', async () => {
+    test('useObservable with a lookup table and empty deps array', () => {
         let num = 0;
         let numInner = 0;
         const obs$: Observable = observable(0);
@@ -1945,7 +2100,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(1);
         expect(value).toEqual('a0');
 
-        await act(async () => {
+        act(() => {
             obs$.set(1);
         });
 
@@ -1953,7 +2108,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(2);
         expect(value).toEqual('a1');
 
-        await act(async () => {
+        act(() => {
             obs$.set(2);
         });
 
@@ -1961,7 +2116,7 @@ describe('useObservable', () => {
         expect(numInner).toEqual(3);
         expect(value).toEqual('a2');
     });
-    test('useComputed with a deps array', async () => {
+    test('useComputed with a deps array', () => {
         let num = 0;
         const obs$: Observable = observable(0);
         let value: string = '';
@@ -1993,7 +2148,7 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual('hi');
 
-        await act(async () => {
+        act(() => {
             deps = ['hello'];
             obs$.set(1);
         });
@@ -2001,7 +2156,7 @@ describe('useObservable', () => {
         expect(num).toEqual(2);
         expect(value).toEqual('hello');
 
-        await act(async () => {
+        act(() => {
             deps = ['hello2'];
             obs$.set(2);
         });
@@ -2009,13 +2164,13 @@ describe('useObservable', () => {
         expect(num).toEqual(3);
         expect(value).toEqual('hello2');
 
-        await act(async () => {
+        act(() => {
             obsLocal$!.set('test');
         });
 
         expect(setTo).toEqual('test');
     });
-    test('useComputed vs observable deep object set', async () => {
+    test('useComputed vs observable deep object set', () => {
         // From: https://github.com/LegendApp/legend-state/issues/305
         const o$ = observable([{ hotspot: { position: { x: 0 } } }]);
         let numRenders = 0;
@@ -2048,21 +2203,21 @@ describe('useObservable', () => {
 
         expect(lastValue).toEqual([{ hotspot: { position: { x: 0 } } }]);
 
-        await act(async () => {
+        act(() => {
             o$[0].hotspot.position.x.set(2);
         });
 
         expect(numRenders).toEqual(2);
         expect(lastValue).toEqual([{ hotspot: { position: { x: 2 } } }]);
 
-        await act(async () => {
+        act(() => {
             o$.set([{ hotspot: { position: { x: 1 } } }]);
         });
 
         expect(numRenders).toEqual(3);
         expect(lastValue).toEqual([{ hotspot: { position: { x: 1 } } }]);
 
-        await act(async () => {
+        act(() => {
             o$[0].hotspot.position.x.set(3);
         });
 
@@ -2105,7 +2260,7 @@ describe('useObservable', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(1 + '_' + originalRand);
 
-        await act(async () => {
+        act(() => {
             obs2$.set(1);
         });
 
@@ -2150,7 +2305,7 @@ describe('useObservable', () => {
         expect(innerDerivedCallCount).toBe(1);
 
         // Unmount the component
-        await act(async () => {
+        act(() => {
             unmount();
         });
 
@@ -2161,13 +2316,13 @@ describe('useObservable', () => {
         const innerDerivedCountAfterUnmount = innerDerivedCallCount;
 
         // Change outer$ multiple times after unmount
-        await act(async () => {
+        act(() => {
             outer$.set(false);
         });
-        await act(async () => {
+        act(() => {
             outer$.set(true);
         });
-        await act(async () => {
+        act(() => {
             outer$.set(false);
         });
 
@@ -2239,7 +2394,7 @@ describe('useObservable', () => {
     });
 });
 describe('useObservableState', () => {
-    test('useObservableState does not select if value not accessed', async () => {
+    test('useObservableState does not select if value not accessed', () => {
         let num = 0;
         let obs$: Observable<number>;
         const Test = function Test() {
@@ -2257,13 +2412,13 @@ describe('useObservableState', () => {
 
         expect(num).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             obs$.set(1);
         });
 
         expect(num).toEqual(1);
     });
-    test('useObservableState select if value accessed', async () => {
+    test('useObservableState select if value accessed', () => {
         let num = 0;
         let obs$: Observable<number>;
         let value = 0;
@@ -2284,7 +2439,7 @@ describe('useObservableState', () => {
         expect(num).toEqual(1);
         expect(value).toEqual(0);
 
-        await act(async () => {
+        act(() => {
             obs$.set(1);
         });
 
@@ -2293,7 +2448,7 @@ describe('useObservableState', () => {
     });
 });
 describe('Reactive', () => {
-    test('Reactive div $className', async () => {
+    test('Reactive div $className', () => {
         const obs$ = observable('hi');
         let num = 0;
         const Test = function Test() {
@@ -2316,7 +2471,7 @@ describe('Reactive', () => {
         expect(items.length).toEqual(1);
         expect(items[0].className).toEqual('hi');
 
-        await act(async () => {
+        act(() => {
             obs$.set('hello');
         });
 
@@ -2331,7 +2486,7 @@ describe('Reactive', () => {
 });
 
 describe('Memo', () => {
-    test('Memo works with function returning function', async () => {
+    test('Memo works with function returning function', () => {
         let num = 0;
         let obs$: Observable<boolean>;
         function A() {
@@ -2357,7 +2512,7 @@ describe('Memo', () => {
 
         expect(num).toEqual(1);
 
-        await act(async () => {
+        act(() => {
             obs$.set(false);
         });
 
@@ -2366,7 +2521,7 @@ describe('Memo', () => {
         items = container.querySelectorAll('div');
         expect(items[0].textContent).toEqual('BB');
     });
-    test('Memo works with a string', async () => {
+    test('Memo works with a string', () => {
         const obs$ = observable({ test: 'hi' });
         const Test = function Test() {
             return (
@@ -2382,7 +2537,7 @@ describe('Memo', () => {
 
         expect(items[0].textContent).toEqual('hi');
 
-        await act(async () => {
+        act(() => {
             obs$.test.set('hello');
         });
 
@@ -2438,7 +2593,7 @@ describe('tracing', () => {
         // Restore console.log after each test
         (console.log as jest.Mock).mockRestore();
     });
-    test('useTraceListeners', async () => {
+    test('useTraceListeners', () => {
         const obs$ = observable(0);
         const Test = observer(function Test() {
             useTraceListeners();
@@ -2451,12 +2606,14 @@ describe('tracing', () => {
 1: `);
 
         // If deps array changes it should refresh observable
-        obs$.set(1);
+        act(() => {
+            obs$.set(1);
+        });
 
         expect(console.log).toHaveBeenCalledWith(`[legend-state] tracking 1 observable:
 1: `);
     });
-    test('useTraceUpdates', async () => {
+    test('useTraceUpdates', () => {
         const obs$ = observable(0);
         const Test = observer(function Test() {
             useTraceUpdates();
@@ -2466,7 +2623,9 @@ describe('tracing', () => {
         render(createElement(Test));
 
         // If deps array changes it should refresh observable
-        obs$.set(1);
+        act(() => {
+            obs$.set(1);
+        });
 
         expect(console.log).toHaveBeenCalledWith(`[legend-state] Rendering because "" changed:
 from: 0

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -500,7 +500,7 @@ describe('useSelector', () => {
         expect(num).toEqual(4);
     });
     test('suspense without observer', async () => {
-        supressActWarning(async () => {
+        await supressActWarning(async () => {
             const obs$ = observable(
                 new Promise<string>((resolve) =>
                     setTimeout(() => {
@@ -532,7 +532,7 @@ describe('useSelector', () => {
         });
     });
     test('suspense with observer', async () => {
-        supressActWarning(async () => {
+        await supressActWarning(async () => {
             const obs$ = observable(
                 new Promise<string>((resolve) =>
                     setTimeout(() => {
@@ -564,7 +564,7 @@ describe('useSelector', () => {
         });
     });
     test('use$ with array length', async () => {
-        supressActWarning(async () => {
+        await supressActWarning(async () => {
             const obs$ = observable<{ todos: number[]; total: number }>({
                 todos: [0],
                 total: (): number => obs$.todos.length,
@@ -582,20 +582,17 @@ describe('useSelector', () => {
             render(createElement(App));
 
             expect(lastValue).toEqual(1);
-            act(() => {
+            await act(async () => {
                 obs$.todos.push(1);
             });
-            await promiseTimeout(0);
             expect(lastValue).toEqual(2);
-            act(async () => {
+            await act(async () => {
                 obs$.todos.splice(0, 1);
             });
-            await promiseTimeout(0);
             expect(lastValue).toEqual(1);
-            act(async () => {
+            await act(async () => {
                 obs$.todos.set([]);
             });
-            await promiseTimeout(0);
             expect(lastValue).toEqual(0);
         });
     });
@@ -672,7 +669,7 @@ describe('useSelector', () => {
             expect(sideEffectValue).toEqual(0);
 
             // Now mount CompTrigger — its selector runs during render and sets sideEffect$.
-            act(() => {
+            await act(async () => {
                 showTrigger$.set(true);
             });
             await promiseTimeout(0);
@@ -718,7 +715,7 @@ describe('useSelector', () => {
             render(createElement(App));
             expect(sideEffectValue).toEqual(0);
 
-            act(() => {
+            await act(async () => {
                 showTrigger$.set(true);
             });
             await promiseTimeout(0);
@@ -2454,9 +2451,7 @@ describe('tracing', () => {
 1: `);
 
         // If deps array changes it should refresh observable
-        await act(async () => {
-            obs$.set(1);
-        });
+        obs$.set(1);
 
         expect(console.log).toHaveBeenCalledWith(`[legend-state] tracking 1 observable:
 1: `);
@@ -2471,9 +2466,7 @@ describe('tracing', () => {
         render(createElement(Test));
 
         // If deps array changes it should refresh observable
-        await act(async () => {
-            obs$.set(1);
-        });
+        obs$.set(1);
 
         expect(console.log).toHaveBeenCalledWith(`[legend-state] Rendering because "" changed:
 from: 0

--- a/tests/reactive-observer.test.tsx
+++ b/tests/reactive-observer.test.tsx
@@ -28,7 +28,7 @@ beforeEach(() => {
 });
 
 describe('reactive', () => {
-    test('strips $ prefix and forwards selected values', () => {
+    test('strips $ prefix and forwards selected values', async () => {
         const value$ = observable('selected');
         let propsPassed: any = undefined;
 
@@ -44,14 +44,14 @@ describe('reactive', () => {
         expect(container.textContent).toBe('rendered');
         expect(propsPassed).toEqual({ value: 'selected', normal: 'plain' });
 
-        act(() => {
+        await act(async () => {
             value$.set('updated');
         });
 
         expect(propsPassed).toEqual({ value: 'updated', normal: 'plain' });
     });
 
-    test('converts children selectors', () => {
+    test('converts children selectors', async () => {
         const children$ = observable('child-result');
         let propsPassed: any = undefined;
 
@@ -66,7 +66,7 @@ describe('reactive', () => {
         expect(propsPassed.children).toBe('child-result');
         expect(container.textContent).toBe('child-result');
 
-        act(() => {
+        await act(async () => {
             children$.set('updated-child');
         });
 
@@ -118,7 +118,7 @@ describe('reactive', () => {
 });
 
 describe('observer', () => {
-    test('wraps component render in useSelector and toggles reactive globals', () => {
+    test('wraps component render in useSelector and toggles reactive globals', async () => {
         let wasInObserver = false;
         const obs$ = observable(0);
 
@@ -135,7 +135,7 @@ describe('observer', () => {
         expect(container.textContent).toBe('hello-0');
         expect(reactGlobals.inObserver).toBe(false);
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
@@ -144,7 +144,7 @@ describe('observer', () => {
 });
 
 describe('reactiveObserver', () => {
-    test('observes component and converts reactive props', () => {
+    test('observes component and converts reactive props', async () => {
         const value$ = observable('selected');
         const obs$ = observable(0);
         let wasInObserver = false;
@@ -165,14 +165,14 @@ describe('reactiveObserver', () => {
         expect(container.textContent).toBe('selected-0');
         expect(reactGlobals.inObserver).toBe(false);
 
-        act(() => {
+        await act(async () => {
             value$.set('updated');
         });
 
         expect(propsPassed.value).toBe('updated');
         expect(container.textContent).toBe('updated-0');
 
-        act(() => {
+        await act(async () => {
             obs$.set(1);
         });
 
@@ -181,7 +181,7 @@ describe('reactiveObserver', () => {
 });
 
 describe('reactiveComponents', () => {
-    test('returns memoized reactive components from map', () => {
+    test('returns memoized reactive components from map', async () => {
         const value$ = observable('selected');
         let propsPassed: any = undefined;
 
@@ -201,7 +201,7 @@ describe('reactiveComponents', () => {
         expect(propsPassed.value).toBe('selected');
         expect(container.textContent).toBe('selected');
 
-        act(() => {
+        await act(async () => {
             value$.set('updated');
         });
 

--- a/tests/reactive-observer.test.tsx
+++ b/tests/reactive-observer.test.tsx
@@ -28,7 +28,7 @@ beforeEach(() => {
 });
 
 describe('reactive', () => {
-    test('strips $ prefix and forwards selected values', async () => {
+    test('strips $ prefix and forwards selected values', () => {
         const value$ = observable('selected');
         let propsPassed: any = undefined;
 
@@ -44,14 +44,14 @@ describe('reactive', () => {
         expect(container.textContent).toBe('rendered');
         expect(propsPassed).toEqual({ value: 'selected', normal: 'plain' });
 
-        await act(async () => {
+        act(() => {
             value$.set('updated');
         });
 
         expect(propsPassed).toEqual({ value: 'updated', normal: 'plain' });
     });
 
-    test('converts children selectors', async () => {
+    test('converts children selectors', () => {
         const children$ = observable('child-result');
         let propsPassed: any = undefined;
 
@@ -66,7 +66,7 @@ describe('reactive', () => {
         expect(propsPassed.children).toBe('child-result');
         expect(container.textContent).toBe('child-result');
 
-        await act(async () => {
+        act(() => {
             children$.set('updated-child');
         });
 
@@ -118,7 +118,7 @@ describe('reactive', () => {
 });
 
 describe('observer', () => {
-    test('wraps component render in useSelector and toggles reactive globals', async () => {
+    test('wraps component render in useSelector and toggles reactive globals', () => {
         let wasInObserver = false;
         const obs$ = observable(0);
 
@@ -135,7 +135,7 @@ describe('observer', () => {
         expect(container.textContent).toBe('hello-0');
         expect(reactGlobals.inObserver).toBe(false);
 
-        await act(async () => {
+        act(() => {
             obs$.set(1);
         });
 
@@ -144,7 +144,7 @@ describe('observer', () => {
 });
 
 describe('reactiveObserver', () => {
-    test('observes component and converts reactive props', async () => {
+    test('observes component and converts reactive props', () => {
         const value$ = observable('selected');
         const obs$ = observable(0);
         let wasInObserver = false;
@@ -165,14 +165,14 @@ describe('reactiveObserver', () => {
         expect(container.textContent).toBe('selected-0');
         expect(reactGlobals.inObserver).toBe(false);
 
-        await act(async () => {
+        act(() => {
             value$.set('updated');
         });
 
         expect(propsPassed.value).toBe('updated');
         expect(container.textContent).toBe('updated-0');
 
-        await act(async () => {
+        act(() => {
             obs$.set(1);
         });
 
@@ -181,7 +181,7 @@ describe('reactiveObserver', () => {
 });
 
 describe('reactiveComponents', () => {
-    test('returns memoized reactive components from map', async () => {
+    test('returns memoized reactive components from map', () => {
         const value$ = observable('selected');
         let propsPassed: any = undefined;
 
@@ -201,7 +201,7 @@ describe('reactiveComponents', () => {
         expect(propsPassed.value).toBe('selected');
         expect(container.textContent).toBe('selected');
 
-        await act(async () => {
+        act(() => {
             value$.set('updated');
         });
 

--- a/tests/testglobals.ts
+++ b/tests/testglobals.ts
@@ -72,7 +72,7 @@ export class ObservablePersistLocalStorage extends ObservablePersistLocalStorage
     }
 }
 
-export function supressActWarning(fn: () => void) {
+export async function supressActWarning(fn: () => Promise<void>) {
     const originalError = console.error;
     console.error = (...args) => {
         if (/act/.test(args[0])) {
@@ -81,7 +81,7 @@ export function supressActWarning(fn: () => void) {
         originalError.call(console, ...args);
     };
 
-    fn();
+    await fn();
 
     console.error = originalError;
 }

--- a/tests/testglobals.ts
+++ b/tests/testglobals.ts
@@ -81,9 +81,11 @@ export async function supressActWarning(fn: () => Promise<void>) {
         originalError.call(console, ...args);
     };
 
-    await fn();
-
-    console.error = originalError;
+    try {
+        await fn();
+    } finally {
+        console.error = originalError;
+    }
 }
 
 export function expectLog(fn: () => any, msg: string, logType: 'log' | 'warn' | 'error', expecter: (prop: any) => any) {


### PR DESCRIPTION
Setting an observable inside a useSelector callback during render causes React to error: "Cannot update a component while rendering a different component". This is because notify (which tells React to re-render) fires synchronously while another component is still rendering. 

Fix: Defer notify to a microtask. Added a test that checks the warning no longer appears.

Related: #144 