### PR TITLE
fix(indexeddb): close stale db on versionchange

### DIFF
--- a/src/persist-plugins/indexeddb.ts
+++ b/src/persist-plugins/indexeddb.ts
@@ -55,6 +55,9 @@ export class ObservablePersistIndexedDB implements ObservablePersistPlugin {
         openRequest.onerror = () => {
             console.error('[legend-state] ObservablePersistIndexedDB load error', openRequest.error);
         };
+        openRequest.onblocked = () => {
+            console.warn('[legend-state] ObservablePersistIndexedDB upgrade blocked by another tab');
+        };
 
         openRequest.onupgradeneeded = (event) => {
             const db = openRequest.result;
@@ -84,6 +87,12 @@ export class ObservablePersistIndexedDB implements ObservablePersistPlugin {
         return new Promise<void>((resolve) => {
             openRequest.onsuccess = async () => {
                 this.db = openRequest.result;
+                this.db.onversionchange = () => {
+                    console.warn(
+                        '[legend-state] ObservablePersistIndexedDB versionchange detected, closing connection',
+                    );
+                    this.db?.close();
+                };
 
                 // Load each table
                 const objectStoreNames = this.db.objectStoreNames;


### PR DESCRIPTION
## Summary

This PR improves IndexedDB upgrade diagnostics and adds the standard connection-handling hook for version changes.

### Changes

- Add `openRequest.onblocked` logging during `indexedDB.open(...)`.
- Add `db.onversionchange` handling after open success and close the stale DB connection.

## Motivation

During app deploys that bump IndexedDB version, some clients can get stuck if upgrade coordination across browser contexts fails. This change follows IndexedDB best practices for cross-context upgrades and improves observability when upgrade contention occurs.

## Problem

`ObservablePersistIndexedDB.initialize()` currently opens the DB and handles upgrade/create, but it does not:
1. Surface blocked-upgrade signals via `onblocked`, or
2. Close old open connections when a `versionchange` is signaled.

Both can make upgrade issues difficult to diagnose and increase the risk of blocked migrations.

## Why This Change

- `onversionchange -> db.close()` is the recommended IndexedDB pattern so old contexts release locks when a newer version is opening.
- `onblocked` logging provides immediate visibility into upgrade contention.

## Scope / Compatibility

- No API changes.
- No persistence format changes.
- Behavior only differs when IndexedDB emits `onblocked` or `onversionchange`.

## Request for Reviewers

If maintainers have a reliable multi-tab/version-upgrade repro harness, please validate:
- Older context receives `versionchange` and closes.
- Newer context proceeds past blocked upgrade.
- Normal persistence behavior remains unchanged afterward.