### PR TITLE
feat: tanstack query plugin improvements, refetch control & state

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -3,6 +3,7 @@
     "testEnvironment": "node",
     "modulePathIgnorePatterns": ["<rootDir>/dist"],
     "moduleNameMapper": {
+        "@legendapp/state/sync-plugins/tanstack-query": "<rootDir>/src/sync-plugins/tanstack-query",
         "@legendapp/state/sync-plugins/crud": "<rootDir>/src/sync-plugins/crud",
         "@legendapp/state/sync": "<rootDir>/sync",
         "@legendapp/state/config/configureLegendState": "<rootDir>/src/config/configureLegendState",

--- a/src/sync-plugins/tanstack-query.ts
+++ b/src/sync-plugins/tanstack-query.ts
@@ -110,7 +110,7 @@ export function syncedQuery<
             const result = observer!.getOptimisticResult(latestOptions);
 
             if (result.isLoading) {
-                await new Promise<TData>((resolve, reject) => {
+                return await new Promise<TData>((resolve, reject) => {
                     resolveInitialPromise = resolve;
                     rejectInitialPromise = reject;
                 });
@@ -118,22 +118,20 @@ export function syncedQuery<
 
             return result.data!;
         } else {
-            // refetchOnMount option from TanStack Query
-            const refetchOnMount = latestOptions.refetchOnMount;
+            const currentResult = observer!.getCurrentResult();
+            const rawRefetchOnMount = latestOptions.refetchOnMount;
+
+            // Resolve callback form: (query) => boolean | 'always'
+            const refetchOnMount =
+                typeof rawRefetchOnMount === 'function'
+                    ? rawRefetchOnMount(queryClient!.getQueryCache().find({ queryKey: latestOptions.queryKey })!)
+                    : rawRefetchOnMount;
 
             if (refetchOnMount === false) {
-                const currentResult = observer!.getCurrentResult();
                 return currentResult.data!;
             }
 
-            if (refetchOnMount === 'always') {
-                return Promise.resolve(observer!.refetch()).then((res) => (res as any).data as TData);
-            }
-
-            // Default behavior (refetchOnMount is true or undefined):
-            // Only refetch if the data is stale
-            const currentResult = observer!.getCurrentResult();
-            if (currentResult.isStale) {
+            if (refetchOnMount === 'always' || currentResult.isStale) {
                 return Promise.resolve(observer!.refetch()).then((res) => (res as any).data as TData);
             }
 

--- a/src/sync-plugins/tanstack-query.ts
+++ b/src/sync-plugins/tanstack-query.ts
@@ -118,24 +118,9 @@ export function syncedQuery<
 
             return result.data!;
         } else {
-            const currentResult = observer!.getCurrentResult();
-            const rawRefetchOnMount = latestOptions.refetchOnMount;
-
-            // Resolve callback form: (query) => boolean | 'always'
-            const refetchOnMount =
-                typeof rawRefetchOnMount === 'function'
-                    ? rawRefetchOnMount(queryClient!.getQueryCache().find({ queryKey: latestOptions.queryKey })!)
-                    : rawRefetchOnMount;
-
-            if (refetchOnMount === false) {
-                return currentResult.data!;
-            }
-
-            if (refetchOnMount === 'always' || currentResult.isStale) {
-                return Promise.resolve(observer!.refetch()).then((res) => (res as any).data as TData);
-            }
-
-            return currentResult.data!;
+            // Subsequent calls (including sync()) always refetch from the server.
+            // TQ observer handles refetchOnMount/staleTime/etc. internally via subscription.
+            return Promise.resolve(observer!.refetch()).then((res) => (res as any).data as TData);
         }
     }) as () => Promise<TData>;
 
@@ -156,14 +141,6 @@ export function syncedQuery<
         const unsubscribe = observer!.subscribe(
             notifyManager.batchCalls((result: QueryObserverResult<TData, TError>) => {
                 emitQueryState(result);
-
-                // Propagate fetching state to syncState
-                if (node.state) {
-                    const isFetching = result.fetchStatus === 'fetching';
-                    if (node.state.isGetting.peek() !== isFetching) {
-                        node.state.isGetting.set(isFetching);
-                    }
-                }
 
                 if (result.status === 'success') {
                     // Clear error on success

--- a/src/sync-plugins/tanstack-query.ts
+++ b/src/sync-plugins/tanstack-query.ts
@@ -9,6 +9,7 @@ import {
     QueryKey,
     QueryObserver,
     QueryObserverOptions,
+    QueryObserverResult,
     notifyManager,
 } from '@tanstack/query-core';
 
@@ -19,11 +20,20 @@ export interface ObservableQueryOptions<TQueryFnData, TError, TData, TQueryKey e
     queryKey?: TQueryKey | (() => TQueryKey);
 }
 
+export interface QueryState<TError = DefaultError> {
+    isLoading: boolean;
+    isFetching: boolean;
+    error: TError | null;
+    status: 'pending' | 'error' | 'success';
+    fetchStatus: 'fetching' | 'paused' | 'idle';
+}
+
 export interface SyncedQueryParams<TQueryFnData, TError, TData, TQueryKey extends QueryKey>
     extends Omit<SyncedOptions<TData>, 'get' | 'set' | 'retry'> {
     queryClient: QueryClient;
     query: ObservableQueryOptions<TQueryFnData, TError, TData, TQueryKey>;
     mutation?: MutationObserverOptions<TQueryFnData, TError, TData>;
+    onQueryStateChange?: (state: QueryState<TError>) => void;
 }
 
 export function syncedQuery<
@@ -32,7 +42,14 @@ export function syncedQuery<
     TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
 >(params: SyncedQueryParams<TQueryFnData, TError, TData, TQueryKey>): Synced<TData> {
-    const { query: options, mutation: mutationOptions, queryClient, initial: initialParam, ...rest } = params;
+    const {
+        query: options,
+        mutation: mutationOptions,
+        queryClient,
+        initial: initialParam,
+        onQueryStateChange,
+        ...rest
+    } = params;
 
     if (initialParam !== undefined) {
         const initialValue = isFunction(initialParam) ? initialParam() : initialParam;
@@ -84,6 +101,7 @@ export function syncedQuery<
     observer = new Observer!<TQueryFnData, TError, TData, TQueryKey>(queryClient!, latestOptions);
 
     let isFirstRun = true;
+    let rejectInitialPromise: undefined | ((error: Error) => void) = undefined;
     const get = (async () => {
         if (isFirstRun) {
             isFirstRun = false;
@@ -92,27 +110,82 @@ export function syncedQuery<
             const result = observer!.getOptimisticResult(latestOptions);
 
             if (result.isLoading) {
-                await new Promise((resolve) => {
+                await new Promise<TData>((resolve, reject) => {
                     resolveInitialPromise = resolve;
+                    rejectInitialPromise = reject;
                 });
             }
 
             return result.data!;
         } else {
-            return Promise.resolve(observer!.refetch()).then((res) => (res as any).data as TData);
+            // refetchOnMount option from TanStack Query
+            const refetchOnMount = latestOptions.refetchOnMount;
+
+            if (refetchOnMount === false) {
+                const currentResult = observer!.getCurrentResult();
+                return currentResult.data!;
+            }
+
+            if (refetchOnMount === 'always') {
+                return Promise.resolve(observer!.refetch()).then((res) => (res as any).data as TData);
+            }
+
+            // Default behavior (refetchOnMount is true or undefined):
+            // Only refetch if the data is stale
+            const currentResult = observer!.getCurrentResult();
+            if (currentResult.isStale) {
+                return Promise.resolve(observer!.refetch()).then((res) => (res as any).data as TData);
+            }
+
+            return currentResult.data!;
         }
     }) as () => Promise<TData>;
 
-    const subscribe = ({ update }: SyncedSubscribeParams<TData>) => {
+    const emitQueryState = (result: QueryObserverResult<TData, TError>) => {
+        if (onQueryStateChange) {
+            onQueryStateChange({
+                isLoading: result.isLoading,
+                isFetching: result.isFetching,
+                error: result.error,
+                status: result.status,
+                fetchStatus: result.fetchStatus,
+            });
+        }
+    };
+
+    const subscribe = ({ update, onError, node }: SyncedSubscribeParams<TData>) => {
         // Subscribe to Query's observer and update the observable
         const unsubscribe = observer!.subscribe(
-            notifyManager.batchCalls((result) => {
+            notifyManager.batchCalls((result: QueryObserverResult<TData, TError>) => {
+                emitQueryState(result);
+
+                // Propagate fetching state to syncState
+                if (node.state) {
+                    const isFetching = result.fetchStatus === 'fetching';
+                    if (node.state.isGetting.peek() !== isFetching) {
+                        node.state.isGetting.set(isFetching);
+                    }
+                }
+
                 if (result.status === 'success') {
+                    // Clear error on success
+                    if (node.state && node.state.error.peek()) {
+                        node.state.error.set(undefined);
+                    }
                     if (resolveInitialPromise) {
                         resolveInitialPromise(result.data);
                         resolveInitialPromise = undefined;
+                        rejectInitialPromise = undefined;
                     }
                     update({ value: result.data });
+                } else if (result.status === 'error') {
+                    // Propagate error to syncState via onError
+                    if (rejectInitialPromise) {
+                        rejectInitialPromise(result.error as Error);
+                        rejectInitialPromise = undefined;
+                        resolveInitialPromise = undefined;
+                    }
+                    onError(result.error as Error);
                 }
             }),
         );

--- a/src/sync-plugins/tanstack-query.ts
+++ b/src/sync-plugins/tanstack-query.ts
@@ -102,7 +102,15 @@ export function syncedQuery<
 
     let isFirstRun = true;
     let rejectInitialPromise: undefined | ((error: Error) => void) = undefined;
+    // Track whether subscribe was just called in this sync cycle.
+    // The sync infrastructure calls subscribe() before get() on (re-)observation,
+    // but skips subscribe() on explicit sync() when already subscribed.
+    let subscribedInThisCycle = false;
+
     const get = (async () => {
+        const wasJustSubscribed = subscribedInThisCycle;
+        subscribedInThisCycle = false;
+
         if (isFirstRun) {
             isFirstRun = false;
 
@@ -117,9 +125,12 @@ export function syncedQuery<
             }
 
             return result.data!;
+        } else if (wasJustSubscribed) {
+            // Re-observation (remount): return cached data, let TQ observer
+            // handle refetch decisions via subscription (refetchOnMount, staleTime, etc.)
+            return observer!.getCurrentResult().data!;
         } else {
-            // Subsequent calls (including sync()) always refetch from the server.
-            // TQ observer handles refetchOnMount/staleTime/etc. internally via subscription.
+            // Explicit sync(): always force refetch from the server
             return Promise.resolve(observer!.refetch()).then((res) => (res as any).data as TData);
         }
     }) as () => Promise<TData>;
@@ -137,6 +148,8 @@ export function syncedQuery<
     };
 
     const subscribe = ({ update, onError, node }: SyncedSubscribeParams<TData>) => {
+        subscribedInThisCycle = true;
+
         // Subscribe to Query's observer and update the observable
         const unsubscribe = observer!.subscribe(
             notifyManager.batchCalls((result: QueryObserverResult<TData, TError>) => {

--- a/tests/sync-plugins/tanstack-query.mock.ts
+++ b/tests/sync-plugins/tanstack-query.mock.ts
@@ -1,0 +1,93 @@
+export function createQueryCoreMock() {
+    const refetchMock = jest.fn(() => Promise.resolve({ data: 'fresh', status: 'success' }));
+    let subscriberCallback: ((result: any) => void) | undefined;
+
+    const defaultResult = {
+        data: 'initial',
+        status: 'success',
+        isLoading: false,
+        isFetching: false,
+        isStale: false,
+        error: null,
+        fetchStatus: 'idle' as const,
+    };
+
+    class QueryObserver {
+        client: any;
+        options: any;
+        notifyOptions: any;
+
+        constructor(client: any, options: any) {
+            this.client = client;
+            this.options = options;
+        }
+
+        getOptimisticResult() {
+            return defaultResult;
+        }
+
+        getCurrentResult() {
+            return defaultResult;
+        }
+
+        setOptions(_options: any, _notifyOptions?: any) {
+            this.options = _options;
+            this.notifyOptions = _notifyOptions;
+        }
+
+        refetch() {
+            return refetchMock();
+        }
+
+        subscribe(cb: any) {
+            subscriberCallback = cb;
+            return () => {
+                subscriberCallback = undefined;
+            };
+        }
+
+        updateResult() {}
+    }
+
+    class MutationObserver {
+        client: any;
+        options: any;
+
+        constructor(client: any, options: any) {
+            this.client = client;
+            this.options = options;
+        }
+
+        mutate(value: any) {
+            return Promise.resolve(value);
+        }
+    }
+
+    class QueryClient {
+        defaultQueryOptions(options: any) {
+            return options;
+        }
+
+        getMutationCache() {
+            return { findAll: () => [], remove: () => {} };
+        }
+    }
+
+    const notifyManager = {
+        batchCalls:
+            (fn: (...args: any[]) => any) =>
+            (...args: any[]) =>
+                fn(...args),
+    };
+
+    return {
+        __esModule: true,
+        QueryObserver,
+        MutationObserver,
+        QueryClient,
+        notifyManager,
+        DefaultError: Error,
+        refetchMock,
+        getSubscriberCallback: () => subscriberCallback,
+    };
+}

--- a/tests/sync-plugins/tanstack-query.test.ts
+++ b/tests/sync-plugins/tanstack-query.test.ts
@@ -1,6 +1,14 @@
 jest.mock('@tanstack/query-core', () => {
     const refetchMock = jest.fn(() => Promise.resolve({ data: 'fresh', status: 'success' }));
-
+    const result = {
+        data: 'initial',
+        status: 'success',
+        isLoading: false,
+        isFetching: false,
+        isStale: false,
+        error: null,
+        fetchStatus: 'idle' as const,
+    };
     class QueryObserver {
         client: any;
         options: any;
@@ -12,27 +20,11 @@ jest.mock('@tanstack/query-core', () => {
         }
 
         getOptimisticResult() {
-            return {
-                data: 'initial',
-                status: 'success',
-                isLoading: false,
-                isFetching: false,
-                isStale: false,
-                error: null,
-                fetchStatus: 'idle' as const,
-            };
+            return result;
         }
 
         getCurrentResult() {
-            return {
-                data: 'initial',
-                status: 'success',
-                isLoading: false,
-                isFetching: false,
-                isStale: false,
-                error: null,
-                fetchStatus: 'idle' as const,
-            };
+            return result;
         }
 
         setOptions(_options: any, _notifyOptions?: any) {

--- a/tests/sync-plugins/tanstack-query.test.ts
+++ b/tests/sync-plugins/tanstack-query.test.ts
@@ -1,92 +1,6 @@
-jest.mock('@tanstack/query-core', () => {
-    const refetchMock = jest.fn(() => Promise.resolve({ data: 'fresh', status: 'success' }));
-    const result = {
-        data: 'initial',
-        status: 'success',
-        isLoading: false,
-        isFetching: false,
-        isStale: false,
-        error: null,
-        fetchStatus: 'idle' as const,
-    };
-    class QueryObserver {
-        client: any;
-        options: any;
-        notifyOptions: any;
+import { createQueryCoreMock } from './tanstack-query.mock';
 
-        constructor(client: any, options: any) {
-            this.client = client;
-            this.options = options;
-        }
-
-        getOptimisticResult() {
-            return result;
-        }
-
-        getCurrentResult() {
-            return result;
-        }
-
-        setOptions(_options: any, _notifyOptions?: any) {
-            this.options = _options;
-            this.notifyOptions = _notifyOptions;
-        }
-
-        refetch() {
-            return refetchMock();
-        }
-
-        subscribe() {
-            return () => {};
-        }
-
-        updateResult() {}
-    }
-
-    class MutationObserver {
-        client: any;
-        options: any;
-
-        constructor(client: any, options: any) {
-            this.client = client;
-            this.options = options;
-        }
-
-        mutate(value: any) {
-            return Promise.resolve(value);
-        }
-    }
-
-    class QueryClient {
-        defaultQueryOptions(options: any) {
-            return options;
-        }
-
-        getMutationCache() {
-            return {
-                findAll: () => [],
-                remove: () => {},
-            };
-        }
-    }
-
-    const notifyManager = {
-        batchCalls:
-            (fn: (...args: any[]) => any) =>
-            (...args: any[]) =>
-                fn(...args),
-    };
-
-    return {
-        __esModule: true,
-        QueryObserver,
-        MutationObserver,
-        QueryClient,
-        notifyManager,
-        DefaultError: Error,
-        refetchMock,
-    };
-});
+jest.mock('@tanstack/query-core', () => createQueryCoreMock());
 
 import { Synced } from '@legendapp/state/sync';
 import { symbolLinked } from '../../src/globals';
@@ -116,12 +30,12 @@ describe('syncedQuery', () => {
         expect(refetchMock).not.toHaveBeenCalled();
     });
 
-    test('subsequent get always refetches (sync equivalence)', async () => {
+    test('re-observation returns cached data without refetching (TQ observer handles refetch)', async () => {
         const queryClient = new QueryClient();
         const linkedFactory = syncedQuery({
             queryClient,
             query: {
-                queryKey: ['test-sync'],
+                queryKey: ['test-reobserve'],
             },
         }) as () => Synced<any>;
 
@@ -129,12 +43,101 @@ describe('syncedQuery', () => {
         await options.get!({});
         refetchMock.mockClear();
 
+        // Simulate re-observation: sync infra calls subscribe() then get()
+        const mockNodeState = {
+            isGetting: { peek: jest.fn(() => false), set: jest.fn() },
+            error: { peek: jest.fn(() => undefined), set: jest.fn() },
+        };
+        options.subscribe!({
+            update: jest.fn(),
+            onError: jest.fn(),
+            node: { state: mockNodeState } as any,
+            value$: {} as any,
+            refresh: jest.fn(),
+            lastSync: undefined,
+        });
+
+        const second = await options.get!({});
+        expect(second).toBe('initial');
+        expect(refetchMock).not.toHaveBeenCalled();
+    });
+
+    test('explicit sync forces refetch even when data is fresh', async () => {
+        const queryClient = new QueryClient();
+        const linkedFactory = syncedQuery({
+            queryClient,
+            query: {
+                queryKey: ['test-explicit-sync'],
+            },
+        }) as () => Synced<any>;
+
+        const options = linkedFactory()[symbolLinked];
+        await options.get!({});
+        refetchMock.mockClear();
+
+        // Explicit sync: get() called without preceding subscribe()
         const second = await options.get!({});
         expect(second).toBe('fresh');
         expect(refetchMock).toHaveBeenCalledTimes(1);
     });
 
     describe('observer integration', () => {
+        test('observer refetch via subscription updates data', async () => {
+            const queryClient = new QueryClient();
+            let subscriberCallback: ((result: any) => void) | undefined;
+            const mockModule = jest.requireMock('@tanstack/query-core') as any;
+            const OrigObserver = mockModule.QueryObserver;
+            const originalSubscribe = OrigObserver.prototype.subscribe;
+
+            OrigObserver.prototype.subscribe = function (cb: any) {
+                subscriberCallback = cb;
+                return () => {
+                    subscriberCallback = undefined;
+                };
+            };
+
+            try {
+                const linkedFactory = syncedQuery({
+                    queryClient,
+                    query: {
+                        queryKey: ['test-subscription-refetch'],
+                    },
+                }) as () => Synced<any>;
+
+                const options = linkedFactory()[symbolLinked];
+                const updateSpy = jest.fn();
+                const mockNodeState = {
+                    isGetting: { peek: jest.fn(() => false), set: jest.fn() },
+                    error: { peek: jest.fn(() => undefined), set: jest.fn() },
+                };
+
+                options.subscribe!({
+                    update: updateSpy,
+                    onError: jest.fn(),
+                    node: { state: mockNodeState } as any,
+                    value$: {} as any,
+                    refresh: jest.fn(),
+                    lastSync: undefined,
+                });
+
+                // Simulate TQ observer firing a refetch result
+                // (e.g., refetchOnMount triggered internally by TQ)
+                subscriberCallback!({
+                    status: 'success',
+                    data: 'refetched-data',
+                    error: null,
+                    isLoading: false,
+                    isFetching: false,
+                    isStale: false,
+                    fetchStatus: 'idle',
+                });
+
+                expect(updateSpy).toHaveBeenCalledWith({ value: 'refetched-data' });
+            } finally {
+                OrigObserver.prototype.subscribe = originalSubscribe;
+            }
+        });
+
         test('error from observer is forwarded to onError and onQueryStateChange', async () => {
             const queryClient = new QueryClient();
             const stateChanges: QueryState[] = [];

--- a/tests/sync-plugins/tanstack-query.test.ts
+++ b/tests/sync-plugins/tanstack-query.test.ts
@@ -4,6 +4,7 @@ jest.mock('@tanstack/query-core', () => {
     class QueryObserver {
         client: any;
         options: any;
+        notifyOptions: any;
 
         constructor(client: any, options: any) {
             this.client = client;
@@ -11,7 +12,32 @@ jest.mock('@tanstack/query-core', () => {
         }
 
         getOptimisticResult() {
-            return { isLoading: false, data: 'initial', status: 'success' };
+            return {
+                data: 'initial',
+                status: 'success',
+                isLoading: false,
+                isFetching: false,
+                isStale: false,
+                error: null,
+                fetchStatus: 'idle' as const,
+            };
+        }
+
+        getCurrentResult() {
+            return {
+                data: 'initial',
+                status: 'success',
+                isLoading: false,
+                isFetching: false,
+                isStale: false,
+                error: null,
+                fetchStatus: 'idle' as const,
+            };
+        }
+
+        setOptions(_options: any, _notifyOptions?: any) {
+            this.options = _options;
+            this.notifyOptions = _notifyOptions;
         }
 
         refetch() {
@@ -66,30 +92,527 @@ jest.mock('@tanstack/query-core', () => {
         QueryClient,
         notifyManager,
         DefaultError: Error,
+        refetchMock,
     };
 });
 
 import { Synced } from '@legendapp/state/sync';
 import { symbolLinked } from '../../src/globals';
-import { syncedQuery } from '../../src/sync-plugins/tanstack-query';
+import { syncedQuery, QueryState } from '../../src/sync-plugins/tanstack-query';
 import { QueryClient } from '@tanstack/query-core';
 
+const { refetchMock } = jest.requireMock('@tanstack/query-core') as { refetchMock: jest.Mock };
+
 describe('syncedQuery', () => {
-    test('get returns refetched data after the initial run', async () => {
+    beforeEach(() => {
+        refetchMock.mockClear();
+        refetchMock.mockImplementation(() => Promise.resolve({ data: 'fresh', status: 'success' }));
+    });
+
+    test('get returns refetched data after the initial run (stale data)', async () => {
         const queryClient = new QueryClient();
-        const linkedFactory = syncedQuery({
-            queryClient,
-            query: {
-                queryKey: ['test'],
-            },
-        }) as () => Synced<any>;
+        const mockModule = jest.requireMock('@tanstack/query-core') as any;
+        const OrigObserver = mockModule.QueryObserver;
+        const originalGetCurrentResult = OrigObserver.prototype.getCurrentResult;
 
-        const options = linkedFactory()[symbolLinked];
+        OrigObserver.prototype.getCurrentResult = function () {
+            return {
+                data: 'initial',
+                status: 'success',
+                isLoading: false,
+                isFetching: false,
+                isStale: true,
+                error: null,
+                fetchStatus: 'idle',
+            };
+        };
 
-        const initial = await options.get!({});
-        expect(initial).toBe('initial');
+        try {
+            const linkedFactory = syncedQuery({
+                queryClient,
+                query: {
+                    queryKey: ['test'],
+                },
+            }) as () => Synced<any>;
 
-        const second = await options.get!({});
-        expect(second).toBe('fresh');
+            const options = linkedFactory()[symbolLinked];
+
+            const initial = await options.get!({});
+            expect(initial).toBe('initial');
+
+            const second = await options.get!({});
+            expect(second).toBe('fresh');
+        } finally {
+            OrigObserver.prototype.getCurrentResult = originalGetCurrentResult;
+        }
+    });
+
+    describe('refetchOnMount control', () => {
+        test('refetchOnMount: false - returns cached data without refetching', async () => {
+            const queryClient = new QueryClient();
+            const linkedFactory = syncedQuery({
+                queryClient,
+                query: {
+                    queryKey: ['test-no-refetch'],
+                    refetchOnMount: false,
+                },
+            }) as () => Synced<any>;
+
+            const options = linkedFactory()[symbolLinked];
+
+            const initial = await options.get!({});
+            expect(initial).toBe('initial');
+
+            refetchMock.mockClear();
+            const second = await options.get!({});
+            expect(second).toBe('initial');
+            expect(refetchMock).not.toHaveBeenCalled();
+        });
+
+        test('refetchOnMount: "always" - always refetches even if data is fresh', async () => {
+            const queryClient = new QueryClient();
+            const linkedFactory = syncedQuery({
+                queryClient,
+                query: {
+                    queryKey: ['test-always-refetch'],
+                    refetchOnMount: 'always',
+                },
+            }) as () => Synced<any>;
+
+            const options = linkedFactory()[symbolLinked];
+
+            const initial = await options.get!({});
+            expect(initial).toBe('initial');
+
+            refetchMock.mockClear();
+            const second = await options.get!({});
+            expect(second).toBe('fresh');
+            expect(refetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        test('refetchOnMount: true - refetches when data is stale', async () => {
+            const queryClient = new QueryClient();
+            const mockModule = jest.requireMock('@tanstack/query-core') as any;
+            const OrigObserver = mockModule.QueryObserver;
+            const originalGetCurrentResult = OrigObserver.prototype.getCurrentResult;
+
+            OrigObserver.prototype.getCurrentResult = function () {
+                return {
+                    data: 'initial',
+                    status: 'success',
+                    isLoading: false,
+                    isFetching: false,
+                    isStale: true,
+                    error: null,
+                    fetchStatus: 'idle',
+                };
+            };
+
+            try {
+                const linkedFactory = syncedQuery({
+                    queryClient,
+                    query: {
+                        queryKey: ['test-stale-refetch'],
+                        refetchOnMount: true,
+                    },
+                }) as () => Synced<any>;
+
+                const options = linkedFactory()[symbolLinked];
+
+                const initial = await options.get!({});
+                expect(initial).toBe('initial');
+
+                refetchMock.mockClear();
+                const second = await options.get!({});
+                expect(second).toBe('fresh');
+                expect(refetchMock).toHaveBeenCalledTimes(1);
+            } finally {
+                OrigObserver.prototype.getCurrentResult = originalGetCurrentResult;
+            }
+        });
+    });
+
+    describe('observer integration', () => {
+        test('error from observer is forwarded to onError and onQueryStateChange', async () => {
+            const queryClient = new QueryClient();
+            const stateChanges: QueryState[] = [];
+            let subscriberCallback: ((result: any) => void) | undefined;
+            const mockModule = jest.requireMock('@tanstack/query-core') as any;
+            const OrigObserver = mockModule.QueryObserver;
+            const originalSubscribe = OrigObserver.prototype.subscribe;
+
+            OrigObserver.prototype.subscribe = function (cb: any) {
+                subscriberCallback = cb;
+                return () => {
+                    subscriberCallback = undefined;
+                };
+            };
+
+            try {
+                const linkedFactory = syncedQuery({
+                    queryClient,
+                    query: {
+                        queryKey: ['test-observer-error'],
+                    },
+                    onQueryStateChange: (state) => {
+                        stateChanges.push({ ...state });
+                    },
+                }) as () => Synced<any>;
+
+                const options = linkedFactory()[symbolLinked];
+
+                const errorSpy = jest.fn();
+                const updateSpy = jest.fn();
+                const mockNodeState = {
+                    isGetting: { peek: jest.fn(() => false), set: jest.fn() },
+                    error: { peek: jest.fn(() => undefined), set: jest.fn() },
+                };
+
+                options.subscribe!({
+                    update: updateSpy,
+                    onError: errorSpy,
+                    node: { state: mockNodeState } as any,
+                    value$: {} as any,
+                    refresh: jest.fn(),
+                    lastSync: undefined,
+                });
+
+                expect(subscriberCallback).toBeDefined();
+
+                const testError = new Error('Query failed');
+                subscriberCallback!({
+                    status: 'error',
+                    error: testError,
+                    isLoading: false,
+                    isFetching: false,
+                    isStale: false,
+                    fetchStatus: 'idle',
+                    data: undefined,
+                });
+
+                expect(errorSpy).toHaveBeenCalledWith(testError);
+                expect(stateChanges).toHaveLength(1);
+                expect(stateChanges[0]).toEqual({
+                    isLoading: false,
+                    isFetching: false,
+                    error: testError,
+                    status: 'error',
+                    fetchStatus: 'idle',
+                });
+            } finally {
+                OrigObserver.prototype.subscribe = originalSubscribe;
+            }
+        });
+
+        test('success from observer updates value and clears error', async () => {
+            const queryClient = new QueryClient();
+            const stateChanges: QueryState[] = [];
+            let subscriberCallback: ((result: any) => void) | undefined;
+
+            const mockModule = jest.requireMock('@tanstack/query-core') as any;
+            const OrigObserver = mockModule.QueryObserver;
+            const originalSubscribe = OrigObserver.prototype.subscribe;
+
+            OrigObserver.prototype.subscribe = function (cb: any) {
+                subscriberCallback = cb;
+                return () => {
+                    subscriberCallback = undefined;
+                };
+            };
+
+            try {
+                const linkedFactory = syncedQuery({
+                    queryClient,
+                    query: {
+                        queryKey: ['test-observer-success'],
+                    },
+                    onQueryStateChange: (state) => {
+                        stateChanges.push({ ...state });
+                    },
+                }) as () => Synced<any>;
+
+                const options = linkedFactory()[symbolLinked];
+
+                const errorSpy = jest.fn();
+                const updateSpy = jest.fn();
+                const prevError = new Error('previous error');
+                const mockNodeState = {
+                    isGetting: { peek: jest.fn(() => false), set: jest.fn() },
+                    error: { peek: jest.fn(() => prevError), set: jest.fn() },
+                };
+
+                options.subscribe!({
+                    update: updateSpy,
+                    onError: errorSpy,
+                    node: { state: mockNodeState } as any,
+                    value$: {} as any,
+                    refresh: jest.fn(),
+                    lastSync: undefined,
+                });
+
+                subscriberCallback!({
+                    status: 'success',
+                    data: 'new-data',
+                    error: null,
+                    isLoading: false,
+                    isFetching: false,
+                    isStale: false,
+                    fetchStatus: 'idle',
+                });
+
+                expect(updateSpy).toHaveBeenCalledWith({ value: 'new-data' });
+                expect(errorSpy).not.toHaveBeenCalled();
+                expect(mockNodeState.error.set).toHaveBeenCalledWith(undefined);
+                expect(stateChanges).toHaveLength(1);
+                expect(stateChanges[0].status).toBe('success');
+                expect(stateChanges[0].error).toBeNull();
+            } finally {
+                OrigObserver.prototype.subscribe = originalSubscribe;
+            }
+        });
+
+        test('isFetching state is propagated to node.state.isGetting', async () => {
+            const queryClient = new QueryClient();
+            let subscriberCallback: ((result: any) => void) | undefined;
+
+            const mockModule = jest.requireMock('@tanstack/query-core') as any;
+            const OrigObserver = mockModule.QueryObserver;
+            const originalSubscribe = OrigObserver.prototype.subscribe;
+
+            OrigObserver.prototype.subscribe = function (cb: any) {
+                subscriberCallback = cb;
+                return () => {
+                    subscriberCallback = undefined;
+                };
+            };
+
+            try {
+                const linkedFactory = syncedQuery({
+                    queryClient,
+                    query: {
+                        queryKey: ['test-observer-fetching'],
+                    },
+                }) as () => Synced<any>;
+
+                const options = linkedFactory()[symbolLinked];
+
+                let currentIsGetting = false;
+                const mockNodeState = {
+                    isGetting: {
+                        peek: jest.fn(() => currentIsGetting),
+                        set: jest.fn((val: boolean) => {
+                            currentIsGetting = val;
+                        }),
+                    },
+                    error: { peek: jest.fn(() => undefined), set: jest.fn() },
+                };
+
+                options.subscribe!({
+                    update: jest.fn(),
+                    onError: jest.fn(),
+                    node: { state: mockNodeState } as any,
+                    value$: {} as any,
+                    refresh: jest.fn(),
+                    lastSync: undefined,
+                });
+
+                subscriberCallback!({
+                    status: 'success',
+                    data: 'data',
+                    error: null,
+                    isLoading: false,
+                    isFetching: true,
+                    isStale: false,
+                    fetchStatus: 'fetching',
+                });
+
+                expect(mockNodeState.isGetting.set).toHaveBeenCalledWith(true);
+
+                mockNodeState.isGetting.set.mockClear();
+                subscriberCallback!({
+                    status: 'success',
+                    data: 'fresh-data',
+                    error: null,
+                    isLoading: false,
+                    isFetching: false,
+                    isStale: false,
+                    fetchStatus: 'idle',
+                });
+
+                expect(mockNodeState.isGetting.set).toHaveBeenCalledWith(false);
+            } finally {
+                OrigObserver.prototype.subscribe = originalSubscribe;
+            }
+        });
+
+        test('onQueryStateChange tracks full lifecycle: loading -> error -> retry -> success', async () => {
+            const queryClient = new QueryClient();
+            const stateChanges: QueryState[] = [];
+            let subscriberCallback: ((result: any) => void) | undefined;
+
+            const mockModule = jest.requireMock('@tanstack/query-core') as any;
+            const OrigObserver = mockModule.QueryObserver;
+            const originalSubscribe = OrigObserver.prototype.subscribe;
+
+            OrigObserver.prototype.subscribe = function (cb: any) {
+                subscriberCallback = cb;
+                return () => {
+                    subscriberCallback = undefined;
+                };
+            };
+
+            try {
+                const linkedFactory = syncedQuery({
+                    queryClient,
+                    query: {
+                        queryKey: ['test-error-recovery'],
+                    },
+                    onQueryStateChange: (state) => {
+                        stateChanges.push({ ...state });
+                    },
+                }) as () => Synced<any>;
+
+                const options = linkedFactory()[symbolLinked];
+                const mockNodeState = {
+                    isGetting: { peek: jest.fn(() => false), set: jest.fn() },
+                    error: { peek: jest.fn(() => undefined), set: jest.fn() },
+                };
+
+                options.subscribe!({
+                    update: jest.fn(),
+                    onError: jest.fn(),
+                    node: { state: mockNodeState } as any,
+                    value$: {} as any,
+                    refresh: jest.fn(),
+                    lastSync: undefined,
+                });
+
+                const networkError = new Error('Network failed');
+
+                // Phase 1: Loading
+                subscriberCallback!({
+                    status: 'pending',
+                    data: undefined,
+                    error: null,
+                    isLoading: true,
+                    isFetching: true,
+                    isStale: false,
+                    fetchStatus: 'fetching',
+                });
+
+                // Phase 2: Error
+                subscriberCallback!({
+                    status: 'error',
+                    data: undefined,
+                    error: networkError,
+                    isLoading: false,
+                    isFetching: false,
+                    isStale: false,
+                    fetchStatus: 'idle',
+                });
+
+                // Phase 3: Retry
+                subscriberCallback!({
+                    status: 'error',
+                    data: undefined,
+                    error: networkError,
+                    isLoading: false,
+                    isFetching: true,
+                    isStale: false,
+                    fetchStatus: 'fetching',
+                });
+
+                // Phase 4: Success
+                subscriberCallback!({
+                    status: 'success',
+                    data: 'recovered-data',
+                    error: null,
+                    isLoading: false,
+                    isFetching: false,
+                    isStale: false,
+                    fetchStatus: 'idle',
+                });
+
+                expect(stateChanges).toHaveLength(4);
+                expect(stateChanges[1]).toMatchObject({ status: 'error', error: networkError });
+                expect(stateChanges[3]).toMatchObject({ status: 'success', error: null });
+            } finally {
+                OrigObserver.prototype.subscribe = originalSubscribe;
+            }
+        });
+
+        test('initial load error rejects the get promise', async () => {
+            const queryClient = new QueryClient();
+            let subscriberCallback: ((result: any) => void) | undefined;
+
+            const mockModule = jest.requireMock('@tanstack/query-core') as any;
+            const OrigObserver = mockModule.QueryObserver;
+            const originalSubscribe = OrigObserver.prototype.subscribe;
+            const originalGetOptimistic = OrigObserver.prototype.getOptimisticResult;
+
+            OrigObserver.prototype.getOptimisticResult = function () {
+                return {
+                    isLoading: true,
+                    data: undefined,
+                    status: 'pending',
+                    isFetching: true,
+                    isStale: false,
+                    error: null,
+                    fetchStatus: 'fetching',
+                };
+            };
+
+            OrigObserver.prototype.subscribe = function (cb: any) {
+                subscriberCallback = cb;
+                return () => {
+                    subscriberCallback = undefined;
+                };
+            };
+
+            try {
+                const linkedFactory = syncedQuery({
+                    queryClient,
+                    query: {
+                        queryKey: ['test-initial-error'],
+                    },
+                }) as () => Synced<any>;
+
+                const options = linkedFactory()[symbolLinked];
+
+                const errorSpy = jest.fn();
+                options.subscribe!({
+                    update: jest.fn(),
+                    onError: errorSpy,
+                    node: {
+                        state: {
+                            isGetting: { peek: jest.fn(() => false), set: jest.fn() },
+                            error: { peek: jest.fn(() => undefined), set: jest.fn() },
+                        },
+                    } as any,
+                    value$: {} as any,
+                    refresh: jest.fn(),
+                    lastSync: undefined,
+                });
+
+                const getPromise = options.get!({});
+
+                const loadError = new Error('Initial load failed');
+                subscriberCallback!({
+                    status: 'error',
+                    data: undefined,
+                    error: loadError,
+                    isLoading: false,
+                    isFetching: false,
+                    isStale: false,
+                    fetchStatus: 'idle',
+                });
+
+                await expect(getPromise).rejects.toThrow('Initial load failed');
+                expect(errorSpy).toHaveBeenCalledWith(loadError);
+            } finally {
+                OrigObserver.prototype.subscribe = originalSubscribe;
+                OrigObserver.prototype.getOptimisticResult = originalGetOptimistic;
+            }
+        });
     });
 });

--- a/tests/sync-plugins/tanstack-query.test.ts
+++ b/tests/sync-plugins/tanstack-query.test.ts
@@ -62,16 +62,6 @@ jest.mock('@tanstack/query-core', () => {
             return options;
         }
 
-        getQueryCache() {
-            return {
-                find: () => ({
-                    state: { dataUpdatedAt: Date.now() },
-                    isStaleByTime: 0,
-                    getObserversCount: () => 1,
-                }),
-            };
-        }
-
         getMutationCache() {
             return {
                 findAll: () => [],

--- a/tests/sync-plugins/tanstack-query.test.ts
+++ b/tests/sync-plugins/tanstack-query.test.ts
@@ -70,6 +70,16 @@ jest.mock('@tanstack/query-core', () => {
             return options;
         }
 
+        getQueryCache() {
+            return {
+                find: () => ({
+                    state: { dataUpdatedAt: Date.now() },
+                    isStaleByTime: 0,
+                    getObserversCount: () => 1,
+                }),
+            };
+        }
+
         getMutationCache() {
             return {
                 findAll: () => [],
@@ -188,6 +198,55 @@ describe('syncedQuery', () => {
             const second = await options.get!({});
             expect(second).toBe('fresh');
             expect(refetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        test('refetchOnMount: callback returning false - returns cached data without refetching', async () => {
+            const queryClient = new QueryClient();
+            const callbackSpy = jest.fn(() => false as const);
+
+            const linkedFactory = syncedQuery({
+                queryClient,
+                query: {
+                    queryKey: ['test-callback-false'],
+                    refetchOnMount: callbackSpy,
+                },
+            }) as () => Synced<any>;
+
+            const options = linkedFactory()[symbolLinked];
+
+            const initial = await options.get!({});
+            expect(initial).toBe('initial');
+
+            refetchMock.mockClear();
+            const second = await options.get!({});
+            expect(second).toBe('initial');
+            expect(refetchMock).not.toHaveBeenCalled();
+            expect(callbackSpy).toHaveBeenCalledTimes(1);
+            expect(callbackSpy).toHaveBeenCalledWith(expect.objectContaining({ state: expect.any(Object) }));
+        });
+
+        test('refetchOnMount: callback returning "always" - always refetches', async () => {
+            const queryClient = new QueryClient();
+            const callbackSpy = jest.fn(() => 'always' as const);
+
+            const linkedFactory = syncedQuery({
+                queryClient,
+                query: {
+                    queryKey: ['test-callback-always'],
+                    refetchOnMount: callbackSpy,
+                },
+            }) as () => Synced<any>;
+
+            const options = linkedFactory()[symbolLinked];
+
+            const initial = await options.get!({});
+            expect(initial).toBe('initial');
+
+            refetchMock.mockClear();
+            const second = await options.get!({});
+            expect(second).toBe('fresh');
+            expect(refetchMock).toHaveBeenCalledTimes(1);
+            expect(callbackSpy).toHaveBeenCalledTimes(1);
         });
 
         test('refetchOnMount: true - refetches when data is stale', async () => {

--- a/tests/sync-plugins/tanstack-query.test.ts
+++ b/tests/sync-plugins/tanstack-query.test.ts
@@ -101,176 +101,37 @@ describe('syncedQuery', () => {
         refetchMock.mockImplementation(() => Promise.resolve({ data: 'fresh', status: 'success' }));
     });
 
-    test('get returns refetched data after the initial run (stale data)', async () => {
+    test('first get returns cached optimistic data', async () => {
         const queryClient = new QueryClient();
-        const mockModule = jest.requireMock('@tanstack/query-core') as any;
-        const OrigObserver = mockModule.QueryObserver;
-        const originalGetCurrentResult = OrigObserver.prototype.getCurrentResult;
+        const linkedFactory = syncedQuery({
+            queryClient,
+            query: {
+                queryKey: ['test-first-get'],
+            },
+        }) as () => Synced<any>;
 
-        OrigObserver.prototype.getCurrentResult = function () {
-            return {
-                data: 'initial',
-                status: 'success',
-                isLoading: false,
-                isFetching: false,
-                isStale: true,
-                error: null,
-                fetchStatus: 'idle',
-            };
-        };
-
-        try {
-            const linkedFactory = syncedQuery({
-                queryClient,
-                query: {
-                    queryKey: ['test'],
-                },
-            }) as () => Synced<any>;
-
-            const options = linkedFactory()[symbolLinked];
-
-            const initial = await options.get!({});
-            expect(initial).toBe('initial');
-
-            const second = await options.get!({});
-            expect(second).toBe('fresh');
-        } finally {
-            OrigObserver.prototype.getCurrentResult = originalGetCurrentResult;
-        }
+        const options = linkedFactory()[symbolLinked];
+        const result = await options.get!({});
+        expect(result).toBe('initial');
+        expect(refetchMock).not.toHaveBeenCalled();
     });
 
-    describe('refetchOnMount control', () => {
-        test('refetchOnMount: false - returns cached data without refetching', async () => {
-            const queryClient = new QueryClient();
-            const linkedFactory = syncedQuery({
-                queryClient,
-                query: {
-                    queryKey: ['test-no-refetch'],
-                    refetchOnMount: false,
-                },
-            }) as () => Synced<any>;
+    test('subsequent get always refetches (sync equivalence)', async () => {
+        const queryClient = new QueryClient();
+        const linkedFactory = syncedQuery({
+            queryClient,
+            query: {
+                queryKey: ['test-sync'],
+            },
+        }) as () => Synced<any>;
 
-            const options = linkedFactory()[symbolLinked];
+        const options = linkedFactory()[symbolLinked];
+        await options.get!({});
+        refetchMock.mockClear();
 
-            const initial = await options.get!({});
-            expect(initial).toBe('initial');
-
-            refetchMock.mockClear();
-            const second = await options.get!({});
-            expect(second).toBe('initial');
-            expect(refetchMock).not.toHaveBeenCalled();
-        });
-
-        test('refetchOnMount: "always" - always refetches even if data is fresh', async () => {
-            const queryClient = new QueryClient();
-            const linkedFactory = syncedQuery({
-                queryClient,
-                query: {
-                    queryKey: ['test-always-refetch'],
-                    refetchOnMount: 'always',
-                },
-            }) as () => Synced<any>;
-
-            const options = linkedFactory()[symbolLinked];
-
-            const initial = await options.get!({});
-            expect(initial).toBe('initial');
-
-            refetchMock.mockClear();
-            const second = await options.get!({});
-            expect(second).toBe('fresh');
-            expect(refetchMock).toHaveBeenCalledTimes(1);
-        });
-
-        test('refetchOnMount: callback returning false - returns cached data without refetching', async () => {
-            const queryClient = new QueryClient();
-            const callbackSpy = jest.fn(() => false as const);
-
-            const linkedFactory = syncedQuery({
-                queryClient,
-                query: {
-                    queryKey: ['test-callback-false'],
-                    refetchOnMount: callbackSpy,
-                },
-            }) as () => Synced<any>;
-
-            const options = linkedFactory()[symbolLinked];
-
-            const initial = await options.get!({});
-            expect(initial).toBe('initial');
-
-            refetchMock.mockClear();
-            const second = await options.get!({});
-            expect(second).toBe('initial');
-            expect(refetchMock).not.toHaveBeenCalled();
-            expect(callbackSpy).toHaveBeenCalledTimes(1);
-            expect(callbackSpy).toHaveBeenCalledWith(expect.objectContaining({ state: expect.any(Object) }));
-        });
-
-        test('refetchOnMount: callback returning "always" - always refetches', async () => {
-            const queryClient = new QueryClient();
-            const callbackSpy = jest.fn(() => 'always' as const);
-
-            const linkedFactory = syncedQuery({
-                queryClient,
-                query: {
-                    queryKey: ['test-callback-always'],
-                    refetchOnMount: callbackSpy,
-                },
-            }) as () => Synced<any>;
-
-            const options = linkedFactory()[symbolLinked];
-
-            const initial = await options.get!({});
-            expect(initial).toBe('initial');
-
-            refetchMock.mockClear();
-            const second = await options.get!({});
-            expect(second).toBe('fresh');
-            expect(refetchMock).toHaveBeenCalledTimes(1);
-            expect(callbackSpy).toHaveBeenCalledTimes(1);
-        });
-
-        test('refetchOnMount: true - refetches when data is stale', async () => {
-            const queryClient = new QueryClient();
-            const mockModule = jest.requireMock('@tanstack/query-core') as any;
-            const OrigObserver = mockModule.QueryObserver;
-            const originalGetCurrentResult = OrigObserver.prototype.getCurrentResult;
-
-            OrigObserver.prototype.getCurrentResult = function () {
-                return {
-                    data: 'initial',
-                    status: 'success',
-                    isLoading: false,
-                    isFetching: false,
-                    isStale: true,
-                    error: null,
-                    fetchStatus: 'idle',
-                };
-            };
-
-            try {
-                const linkedFactory = syncedQuery({
-                    queryClient,
-                    query: {
-                        queryKey: ['test-stale-refetch'],
-                        refetchOnMount: true,
-                    },
-                }) as () => Synced<any>;
-
-                const options = linkedFactory()[symbolLinked];
-
-                const initial = await options.get!({});
-                expect(initial).toBe('initial');
-
-                refetchMock.mockClear();
-                const second = await options.get!({});
-                expect(second).toBe('fresh');
-                expect(refetchMock).toHaveBeenCalledTimes(1);
-            } finally {
-                OrigObserver.prototype.getCurrentResult = originalGetCurrentResult;
-            }
-        });
+        const second = await options.get!({});
+        expect(second).toBe('fresh');
+        expect(refetchMock).toHaveBeenCalledTimes(1);
     });
 
     describe('observer integration', () => {
@@ -407,80 +268,6 @@ describe('syncedQuery', () => {
                 expect(stateChanges).toHaveLength(1);
                 expect(stateChanges[0].status).toBe('success');
                 expect(stateChanges[0].error).toBeNull();
-            } finally {
-                OrigObserver.prototype.subscribe = originalSubscribe;
-            }
-        });
-
-        test('isFetching state is propagated to node.state.isGetting', async () => {
-            const queryClient = new QueryClient();
-            let subscriberCallback: ((result: any) => void) | undefined;
-
-            const mockModule = jest.requireMock('@tanstack/query-core') as any;
-            const OrigObserver = mockModule.QueryObserver;
-            const originalSubscribe = OrigObserver.prototype.subscribe;
-
-            OrigObserver.prototype.subscribe = function (cb: any) {
-                subscriberCallback = cb;
-                return () => {
-                    subscriberCallback = undefined;
-                };
-            };
-
-            try {
-                const linkedFactory = syncedQuery({
-                    queryClient,
-                    query: {
-                        queryKey: ['test-observer-fetching'],
-                    },
-                }) as () => Synced<any>;
-
-                const options = linkedFactory()[symbolLinked];
-
-                let currentIsGetting = false;
-                const mockNodeState = {
-                    isGetting: {
-                        peek: jest.fn(() => currentIsGetting),
-                        set: jest.fn((val: boolean) => {
-                            currentIsGetting = val;
-                        }),
-                    },
-                    error: { peek: jest.fn(() => undefined), set: jest.fn() },
-                };
-
-                options.subscribe!({
-                    update: jest.fn(),
-                    onError: jest.fn(),
-                    node: { state: mockNodeState } as any,
-                    value$: {} as any,
-                    refresh: jest.fn(),
-                    lastSync: undefined,
-                });
-
-                subscriberCallback!({
-                    status: 'success',
-                    data: 'data',
-                    error: null,
-                    isLoading: false,
-                    isFetching: true,
-                    isStale: false,
-                    fetchStatus: 'fetching',
-                });
-
-                expect(mockNodeState.isGetting.set).toHaveBeenCalledWith(true);
-
-                mockNodeState.isGetting.set.mockClear();
-                subscriberCallback!({
-                    status: 'success',
-                    data: 'fresh-data',
-                    error: null,
-                    isLoading: false,
-                    isFetching: false,
-                    isStale: false,
-                    fetchStatus: 'idle',
-                });
-
-                expect(mockNodeState.isGetting.set).toHaveBeenCalledWith(false);
             } finally {
                 OrigObserver.prototype.subscribe = originalSubscribe;
             }

--- a/tests/sync-plugins/tanstack-react-query.test.tsx
+++ b/tests/sync-plugins/tanstack-react-query.test.tsx
@@ -1,0 +1,282 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+if (typeof document === 'undefined') {
+    GlobalRegistrator.register();
+}
+
+import { createQueryCoreMock } from './tanstack-query.mock';
+
+jest.mock('@tanstack/query-core', () => createQueryCoreMock());
+
+jest.mock('@tanstack/react-query', () => {
+    const { QueryClient } = jest.requireMock('@tanstack/query-core');
+    const defaultClient = new QueryClient();
+    return {
+        __esModule: true,
+        useQueryClient: () => defaultClient,
+    };
+});
+
+import { createElement, useState } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { syncState } from '@legendapp/state';
+import { observer } from '../../src/react/reactive-observer';
+import { useObservableSyncedQuery } from '../../src/sync-plugins/tanstack-react-query';
+import { QueryClient } from '@tanstack/query-core';
+
+const { refetchMock, getSubscriberCallback } = jest.requireMock('@tanstack/query-core') as {
+    refetchMock: jest.Mock;
+    getSubscriberCallback: () => ((result: any) => void) | undefined;
+};
+
+const promiseTimeout = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('useObservableSyncedQuery', () => {
+    beforeEach(() => {
+        refetchMock.mockClear();
+        refetchMock.mockImplementation(() => Promise.resolve({ data: 'fresh', status: 'success' }));
+    });
+
+    test('renders initial cached data without refetching', async () => {
+        const Test = observer(function Test() {
+            const data$ = useObservableSyncedQuery<string>({
+                queryClient: new QueryClient(),
+                query: { queryKey: ['cached-render'] },
+            });
+            return createElement('div', { 'data-testid': 'value' }, String(data$.get()));
+        });
+
+        const { getByTestId } = render(createElement(Test));
+        await waitFor(() => promiseTimeout(0));
+
+        expect(getByTestId('value').textContent).toBe('initial');
+        expect(refetchMock).not.toHaveBeenCalled();
+    });
+
+    test('component remount does not trigger refetch when data is fresh', async () => {
+        const queryClient = new QueryClient();
+
+        const Test = observer(function Test() {
+            const data$ = useObservableSyncedQuery<string>({
+                queryClient,
+                query: { queryKey: ['remount-fresh'] },
+            });
+            return createElement('div', { 'data-testid': 'value' }, String(data$.get()));
+        });
+
+        const { unmount, getByTestId } = render(createElement(Test));
+        await waitFor(() => promiseTimeout(0));
+        expect(getByTestId('value').textContent).toBe('initial');
+
+        refetchMock.mockClear();
+        unmount();
+
+        // Remount the same component with the same queryClient
+        const { getByTestId: getByTestId2 } = render(createElement(Test));
+        await waitFor(() => promiseTimeout(0));
+
+        expect(getByTestId2('value').textContent).toBe('initial');
+        expect(refetchMock).not.toHaveBeenCalled();
+    });
+
+    test('observer subscription pushes new data into the component', async () => {
+        const queryClient = new QueryClient();
+
+        const Test = observer(function Test() {
+            const data$ = useObservableSyncedQuery<string>({
+                queryClient,
+                query: { queryKey: ['subscription-push'] },
+            });
+            return createElement('div', { 'data-testid': 'value' }, String(data$.get()));
+        });
+
+        const { getByTestId } = render(createElement(Test));
+        await waitFor(() => promiseTimeout(0));
+        expect(getByTestId('value').textContent).toBe('initial');
+
+        // Simulate TQ observer pushing a background refetch result
+        const cb = getSubscriberCallback();
+        expect(cb).toBeDefined();
+
+        act(() => {
+            cb!({
+                status: 'success',
+                data: 'background-update',
+                error: null,
+                isLoading: false,
+                isFetching: false,
+                isStale: false,
+                fetchStatus: 'idle',
+            });
+        });
+
+        await waitFor(() => promiseTimeout(0));
+        expect(getByTestId('value').textContent).toBe('background-update');
+    });
+
+    test('onQueryStateChange receives state updates in component context', async () => {
+        const queryClient = new QueryClient();
+        const stateChanges: any[] = [];
+
+        const Test = observer(function Test() {
+            const data$ = useObservableSyncedQuery<string>({
+                queryClient,
+                query: { queryKey: ['state-change'] },
+                onQueryStateChange: (state) => {
+                    stateChanges.push({ ...state });
+                },
+            });
+            return createElement('div', { 'data-testid': 'value' }, String(data$.get()));
+        });
+
+        render(createElement(Test));
+        await waitFor(() => promiseTimeout(0));
+
+        const cb = getSubscriberCallback();
+        act(() => {
+            cb!({
+                status: 'success',
+                data: 'updated',
+                error: null,
+                isLoading: false,
+                isFetching: true,
+                isStale: false,
+                fetchStatus: 'fetching',
+            });
+        });
+
+        await waitFor(() => promiseTimeout(0));
+
+        expect(stateChanges.length).toBeGreaterThanOrEqual(1);
+        const lastState = stateChanges[stateChanges.length - 1];
+        expect(lastState.isFetching).toBe(true);
+        expect(lastState.fetchStatus).toBe('fetching');
+    });
+
+    test('error from observer is reflected via onQueryStateChange', async () => {
+        const queryClient = new QueryClient();
+        const stateChanges: any[] = [];
+
+        const Test = observer(function Test() {
+            const data$ = useObservableSyncedQuery<string>({
+                queryClient,
+                query: { queryKey: ['error-component'] },
+                onQueryStateChange: (state) => {
+                    stateChanges.push({ ...state });
+                },
+            });
+            return createElement('div', { 'data-testid': 'value' }, String(data$.get() ?? 'loading'));
+        });
+
+        render(createElement(Test));
+        await waitFor(() => promiseTimeout(0));
+
+        const cb = getSubscriberCallback();
+        const testError = new Error('Network failure');
+
+        // The sync infrastructure's onGetError re-throws errors, so we need to catch it
+        try {
+            act(() => {
+                cb!({
+                    status: 'error',
+                    data: undefined,
+                    error: testError,
+                    isLoading: false,
+                    isFetching: false,
+                    isStale: false,
+                    fetchStatus: 'idle',
+                });
+            });
+        } catch {
+            // sync infrastructure re-throws errors from subscribe
+        }
+
+        await waitFor(() => promiseTimeout(0));
+
+        const errorState = stateChanges.find((s) => s.status === 'error');
+        expect(errorState).toBeDefined();
+        expect(errorState!.error.message).toBe('Network failure');
+    });
+
+    test('manual .sync() forces refetch even when data is not stale', async () => {
+        const queryClient = new QueryClient();
+        let data$Ref: any;
+
+        const Test = observer(function Test() {
+            const data$ = useObservableSyncedQuery<string>({
+                queryClient,
+                query: { queryKey: ['manual-sync'] },
+            });
+            data$Ref = data$;
+            return createElement('div', { 'data-testid': 'value' }, String(data$.get()));
+        });
+
+        const { getByTestId } = render(createElement(Test));
+        await waitFor(() => promiseTimeout(0));
+
+        expect(getByTestId('value').textContent).toBe('initial');
+        expect(refetchMock).toHaveBeenCalledTimes(0);
+
+        // Data is not stale (mock returns isStale: false), but manual sync should force refetch
+        await act(async () => {
+            await syncState(data$Ref).sync();
+        });
+
+        await waitFor(() => promiseTimeout(0));
+        expect(refetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('multiple re-renders do not refetch, but sync() does', async () => {
+        const queryClient = new QueryClient();
+        let data$Ref: any;
+        let triggerRerender: () => void;
+
+        const Child = observer(function Child() {
+            const data$ = useObservableSyncedQuery<string>({
+                queryClient,
+                query: { queryKey: ['multi-rerender-sync'] },
+            });
+            data$Ref = data$;
+            return createElement('div', { 'data-testid': 'value' }, String(data$.get()));
+        });
+
+        function Parent() {
+            const [count, setCount] = useState(0);
+            triggerRerender = () => setCount((c) => c + 1);
+            return createElement('div', null, createElement('span', null, `render-${count}`), createElement(Child));
+        }
+
+        const { getByTestId } = render(createElement(Parent));
+        await waitFor(() => promiseTimeout(0));
+        expect(getByTestId('value').textContent).toBe('initial');
+        expect(refetchMock).toHaveBeenCalledTimes(0);
+
+        // Re-render #1
+        act(() => triggerRerender());
+        await waitFor(() => promiseTimeout(0));
+        expect(refetchMock).toHaveBeenCalledTimes(0);
+
+        // Re-render #2
+        act(() => triggerRerender());
+        await waitFor(() => promiseTimeout(0));
+        expect(refetchMock).toHaveBeenCalledTimes(0);
+
+        // Re-render #3
+        act(() => triggerRerender());
+        await waitFor(() => promiseTimeout(0));
+        expect(refetchMock).toHaveBeenCalledTimes(0);
+
+        // Now explicit sync() — should force refetch
+        await act(async () => {
+            await syncState(data$Ref).sync();
+        });
+        await waitFor(() => promiseTimeout(0));
+        expect(refetchMock).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            await syncState(data$Ref).sync();
+        });
+        await waitFor(() => promiseTimeout(0));
+        expect(refetchMock).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
## Problem

Two gaps in the TanStack Query integration were causing problems:

### 1. No distinction between re-observation and explicit sync

On main, `get()` called `observer.refetch()` on every call after the first, whether the observable was simply being re-observed (remount) or the user explicitly called `state$.sync()`. This meant every re-observation triggered a network request, bypassing TQ's own refetch policies (`refetchOnMount`, `staleTime`, etc.). It also meant there was no way to distinguish "the component remounted" from "the user wants fresh data now".

### 2. Loading & error states were silently swallowed

The `subscribe` callback only handled `status === 'success'`. Errors were ignored, initial load errors couldn't reject the `get()` promise, and there was no way to observe TQ's granular state (`isFetching`, `fetchStatus`, etc.).

## Solution

### 1. Re-observation vs explicit sync

The `get` function now uses a `subscribedInThisCycle` flag to distinguish the two cases. The sync infrastructure calls `subscribe()` before `get()` on (re-)observation, but skips `subscribe()` on an explicit `sync()` when already subscribed:

| Call | Behavior |
| --- | --- |
| First `get()` (mount) | Return cached/optimistic data from TQ; await the observer if still loading |
| Re-observation (`subscribe()` then `get()`) | Return cached data. TQ's observer handles refetch decisions via subscription (`refetchOnMount`, `staleTime`, etc.) |
| Explicit `sync()` (`get()` without preceding `subscribe()`) | Always call `observer.refetch()`, guaranteed fresh data |

### 2. Error propagation & state exposure

Two layers of state propagation were added to the `subscribe` callback:

- **Errors** flow through `onError()` into `syncState.error`, and are auto-cleared on the next success.
- **Initial load errors** reject the `get()` promise via `rejectInitialPromise`.
- **`onQueryStateChange`** a new opt-in callback for full TQ observer state:

```tsx
syncedQuery({
    query: { queryKey: ['todos'] },
    queryClient,
    onQueryStateChange: ({ isLoading, isFetching, error, status, fetchStatus }) => {
        // React to any TQ state change
    },
});

interface QueryState<TError = DefaultError> {
    isLoading: boolean;
    isFetching: boolean;
    error: TError | null;
    status: 'pending' | 'error' | 'success';
    fetchStatus: 'fetching' | 'paused' | 'idle';
}
```