### PR TITLE
fix: type fieldUpdatedAt/fieldCreatedAt as Date in CRUD callbacks

### DIFF
--- a/src/sync-plugins/crud.ts
+++ b/src/sync-plugins/crud.ts
@@ -70,18 +70,37 @@ export interface CrudErrorParams extends Omit<SyncedErrorParams, 'source'> {
 
 export type CrudOnErrorFn = (error: Error, params: CrudErrorParams) => void;
 
-export interface SyncedCrudPropsBase<TRemote extends object, TLocal = TRemote>
+// clone() uses a JSON reviver that converts ISO 8601 strings to Date objects.
+// These utility types reflect that conversion in the callback parameter types
+// when fieldUpdatedAt/fieldCreatedAt are specified.
+type DateFieldKeys<FUpdatedAt, FCreatedAt> =
+    (FUpdatedAt extends string ? FUpdatedAt : never) |
+    (FCreatedAt extends string ? FCreatedAt : never);
+
+type WithClonedDates<T, K extends string> = [K] extends [never]
+    ? T
+    : { [P in keyof T]: P extends K ? Date : T[P] } & {};
+
+type CrudCallbackInput<TRemote, FUpdatedAt, FCreatedAt> =
+    WithClonedDates<TRemote, DateFieldKeys<FUpdatedAt, FCreatedAt>>;
+
+export interface SyncedCrudPropsBase<
+    TRemote extends object,
+    TLocal = TRemote,
+    FUpdatedAt extends (string & keyof TRemote) | undefined = undefined,
+    FCreatedAt extends (string & keyof TRemote) | undefined = undefined,
+>
     extends Omit<SyncedOptions<TRemote, TLocal>, 'get' | 'set' | 'initial' | 'subscribe' | 'waitForSet' | 'onError'> {
-    create?(input: TRemote, params: SyncedSetParams<TRemote>): Promise<CrudResult<TRemote> | null | undefined | void>;
+    create?(input: CrudCallbackInput<TRemote, FUpdatedAt, FCreatedAt>, params: SyncedSetParams<TRemote>): Promise<CrudResult<TRemote> | null | undefined | void>;
     update?(
-        input: Partial<TRemote>,
+        input: Partial<CrudCallbackInput<TRemote, FUpdatedAt, FCreatedAt>>,
         params: SyncedSetParams<TRemote>,
     ): Promise<CrudResult<Partial<TRemote> | null | undefined | void>>;
-    delete?(input: TRemote, params: SyncedSetParams<TRemote>): Promise<any>;
+    delete?(input: CrudCallbackInput<TRemote, FUpdatedAt, FCreatedAt>, params: SyncedSetParams<TRemote>): Promise<any>;
     onSaved?(params: SyncedCrudOnSavedParams<TRemote, TLocal>): Partial<TLocal> | void;
     fieldId?: string;
-    fieldUpdatedAt?: string;
-    fieldCreatedAt?: string;
+    fieldUpdatedAt?: FUpdatedAt;
+    fieldCreatedAt?: FCreatedAt;
     fieldDeleted?: string;
     fieldDeletedList?: string;
     updatePartial?: boolean;
@@ -217,20 +236,20 @@ function retrySet(
 }
 
 // The no read version
-export function syncedCrud<TRemote extends object, TLocal = TRemote, TAsOption extends CrudAsOption = 'object'>(
-    props: SyncedCrudPropsNoRead<TRemote, TAsOption> & SyncedCrudPropsBase<TRemote, TLocal>,
+export function syncedCrud<TRemote extends object, TLocal = TRemote, TAsOption extends CrudAsOption = 'object', FUpdatedAt extends (string & keyof TRemote) | undefined = undefined, FCreatedAt extends (string & keyof TRemote) | undefined = undefined>(
+    props: SyncedCrudPropsNoRead<TRemote, TAsOption> & SyncedCrudPropsBase<TRemote, TLocal, FUpdatedAt, FCreatedAt>,
 ): SyncedCrudReturnType<TLocal, TAsOption>;
 // The get version
-export function syncedCrud<TRemote extends object, TLocal = TRemote>(
-    props: SyncedCrudPropsSingle<TRemote, TLocal> & SyncedCrudPropsBase<TRemote, TLocal>,
+export function syncedCrud<TRemote extends object, TLocal = TRemote, FUpdatedAt extends (string & keyof TRemote) | undefined = undefined, FCreatedAt extends (string & keyof TRemote) | undefined = undefined>(
+    props: SyncedCrudPropsSingle<TRemote, TLocal> & SyncedCrudPropsBase<TRemote, TLocal, FUpdatedAt, FCreatedAt>,
 ): SyncedCrudReturnType<TLocal, 'value'>;
 // The list version
-export function syncedCrud<TRemote extends object, TLocal = TRemote, TAsOption extends CrudAsOption = 'object'>(
-    props: SyncedCrudPropsMany<TRemote, TLocal, TAsOption> & SyncedCrudPropsBase<TRemote, TLocal>,
+export function syncedCrud<TRemote extends object, TLocal = TRemote, TAsOption extends CrudAsOption = 'object', FUpdatedAt extends (string & keyof TRemote) | undefined = undefined, FCreatedAt extends (string & keyof TRemote) | undefined = undefined>(
+    props: SyncedCrudPropsMany<TRemote, TLocal, TAsOption> & SyncedCrudPropsBase<TRemote, TLocal, FUpdatedAt, FCreatedAt>,
 ): SyncedCrudReturnType<TLocal, Exclude<TAsOption, 'value'>>;
-export function syncedCrud<TRemote extends object, TLocal = TRemote, TAsOption extends CrudAsOption = 'object'>(
+export function syncedCrud<TRemote extends object, TLocal = TRemote, TAsOption extends CrudAsOption = 'object', FUpdatedAt extends (string & keyof TRemote) | undefined = undefined, FCreatedAt extends (string & keyof TRemote) | undefined = undefined>(
     props: (SyncedCrudPropsSingle<TRemote, TLocal> | SyncedCrudPropsMany<TRemote, TLocal, TAsOption>) &
-        SyncedCrudPropsBase<TRemote, TLocal>,
+        SyncedCrudPropsBase<TRemote, TLocal, FUpdatedAt, FCreatedAt>,
 ): SyncedCrudReturnType<TLocal, TAsOption>;
 export function syncedCrud<TRemote extends object, TLocal = TRemote, TAsOption extends CrudAsOption = 'object'>(
     props: (

--- a/tests/crud.test.ts
+++ b/tests/crud.test.ts
@@ -3931,3 +3931,63 @@ describe('generateId', () => {
         expect(value).toEqual([{ id: 'id2', test: 'hello' }]); // fails, saved remains undefined
     });
 });
+
+// Type-only tests for fieldUpdatedAt/fieldCreatedAt Date inference.
+// clone() uses a JSON reviver that converts ISO 8601 strings to Date at runtime;
+// these tests verify the callback parameter types reflect that conversion.
+describe('syncedCrud date field types', () => {
+    interface Task {
+        id: string;
+        title: string;
+        completed: boolean;
+        createdAt: string;
+        updatedAt: string;
+    }
+
+    it('types date fields as Date when both fieldUpdatedAt and fieldCreatedAt are set', () => {
+        syncedCrud({
+            list: async () => [] as Task[],
+            create: (input) => {
+                expectTypeOf(input.createdAt).toEqualTypeOf<Date>();
+                expectTypeOf(input.updatedAt).toEqualTypeOf<Date>();
+                expectTypeOf(input.title).toEqualTypeOf<string>();
+                expectTypeOf(input.id).toEqualTypeOf<string>();
+                return Promise.resolve(undefined);
+            },
+            update: (input) => {
+                expectTypeOf(input.updatedAt).toEqualTypeOf<Date | undefined>();
+                expectTypeOf(input.title).toEqualTypeOf<string | undefined>();
+                return Promise.resolve(undefined);
+            },
+            delete: (input) => {
+                expectTypeOf(input.createdAt).toEqualTypeOf<Date>();
+                return Promise.resolve(undefined);
+            },
+            fieldUpdatedAt: 'updatedAt',
+            fieldCreatedAt: 'createdAt',
+        });
+    });
+
+    it('leaves types unchanged when no date fields are specified', () => {
+        syncedCrud({
+            list: async () => [] as Task[],
+            create: (input) => {
+                expectTypeOf(input.createdAt).toEqualTypeOf<string>();
+                expectTypeOf(input.updatedAt).toEqualTypeOf<string>();
+                return Promise.resolve(undefined);
+            },
+        });
+    });
+
+    it('only types the specified field as Date', () => {
+        syncedCrud({
+            list: async () => [] as Task[],
+            create: (input) => {
+                expectTypeOf(input.updatedAt).toEqualTypeOf<Date>();
+                expectTypeOf(input.createdAt).toEqualTypeOf<string>();
+                return Promise.resolve(undefined);
+            },
+            fieldUpdatedAt: 'updatedAt',
+        });
+    });
+});


### PR DESCRIPTION
## Summary

`clone()` uses a JSON reviver that converts ISO 8601 strings to `Date` objects at runtime. When `fieldUpdatedAt` or `fieldCreatedAt` is specified in `syncedCrud`, the `create`/`update`/`delete` callback parameters receive `Date` values for those fields — but the TypeScript types still say `string`.

This PR makes the types honest by:

- Adding `FUpdatedAt`/`FCreatedAt` string literal type params to `SyncedCrudPropsBase` and all `syncedCrud` overloads
- Using a `CrudCallbackInput` utility type that remaps the specified field keys from `string` to `Date`
- When neither field is set, types are unchanged (fully backwards compatible)

### Before

```typescript
syncedCrud({
    list: async () => fetchTasks(),
    create: (input) => {
        // TypeScript says input.createdAt is `string`
        // Runtime: input.createdAt is a Date object
        console.log(input.createdAt instanceof Date); // true
    },
    fieldUpdatedAt: 'updatedAt',
    fieldCreatedAt: 'createdAt',
});
```

### After

```typescript
syncedCrud({
    list: async () => fetchTasks(),
    create: (input) => {
        // TypeScript correctly says input.createdAt is `Date`
        input.createdAt.toISOString(); // ✓ no error
    },
    fieldUpdatedAt: 'updatedAt',
    fieldCreatedAt: 'createdAt',
});
```

## Caveat

TypeScript doesn't support partial type argument inference. If the user explicitly specifies `TRemote` (e.g. `syncedCrud<Task>({...})`), `FUpdatedAt`/`FCreatedAt` fall back to `undefined` and the date fields stay typed as `string`. This only affects the explicit-generic case — the common pattern of letting `TRemote` be inferred from `list`/`get` works correctly.

## Test plan

- [x] With both `fieldUpdatedAt` and `fieldCreatedAt` set: date fields typed as `Date`, others unchanged
- [x] Without either field set: all types unchanged (backwards compat)
- [x] With only `fieldUpdatedAt`: only that field becomes `Date`, `fieldCreatedAt` stays `string`
- [x] Zero new type errors introduced (all 57 existing errors are pre-existing in supabase/tanstack-query/react files)