### PR TITLE
docs: warn about Date coercion in CRUD callback inputs

### DIFF
--- a/src/sync-plugins/crud.ts
+++ b/src/sync-plugins/crud.ts
@@ -72,11 +72,14 @@ export type CrudOnErrorFn = (error: Error, params: CrudErrorParams) => void;
 
 export interface SyncedCrudPropsBase<TRemote extends object, TLocal = TRemote>
     extends Omit<SyncedOptions<TRemote, TLocal>, 'get' | 'set' | 'initial' | 'subscribe' | 'waitForSet' | 'onError'> {
+    /** **Note:** `input` fields named by `fieldUpdatedAt`/`fieldCreatedAt` will be `Date` at runtime, not the declared type — clone()'s JSON reviver converts ISO 8601 strings. */
     create?(input: TRemote, params: SyncedSetParams<TRemote>): Promise<CrudResult<TRemote> | null | undefined | void>;
+    /** **Note:** `input` fields named by `fieldUpdatedAt`/`fieldCreatedAt` will be `Date` at runtime, not the declared type — clone()'s JSON reviver converts ISO 8601 strings. */
     update?(
         input: Partial<TRemote>,
         params: SyncedSetParams<TRemote>,
     ): Promise<CrudResult<Partial<TRemote> | null | undefined | void>>;
+    /** **Note:** `input` fields named by `fieldUpdatedAt`/`fieldCreatedAt` will be `Date` at runtime, not the declared type — clone()'s JSON reviver converts ISO 8601 strings. */
     delete?(input: TRemote, params: SyncedSetParams<TRemote>): Promise<any>;
     onSaved?(params: SyncedCrudOnSavedParams<TRemote, TLocal>): Partial<TLocal> | void;
     fieldId?: string;


### PR DESCRIPTION
## Summary

- Adds JSDoc to `create`, `update`, and `delete` on `SyncedCrudPropsBase` warning that fields named by `fieldUpdatedAt`/`fieldCreatedAt` will be `Date` at runtime, not the declared type

`clone()` uses a JSON reviver that converts ISO 8601 strings to `Date` objects. When `fieldUpdatedAt` or `fieldCreatedAt` is set, the corresponding fields on the callback `input` parameter are `Date` at runtime — but the TypeScript types still reflect the original declared type (e.g. `string` or `number`). This can cause silent failures when passing those values to APIs that expect strings.

The JSDoc surfaces this in the IDE on hover so consumers are aware of the mismatch.

## Test plan

- No type or runtime changes — JSDoc only