### PR TITLE
fix: fire computed listeners for Temporal values

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@evilmartians/lefthook": "^1.6.13",
         "@happy-dom/global-registrator": "^14.12.0",
         "@jest/globals": "^29.7.0",
+        "@js-temporal/polyfill": "^0.5.1",
         "@react-native-async-storage/async-storage": "^1.23.1",
         "@release-it/conventional-changelog": "^8.0.1",
         "@supabase/supabase-js": "^2.43.4",
@@ -642,6 +643,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.4.14", "", {}, "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.18", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.0", "@jridgewell/sourcemap-codec": "1.4.14" } }, "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA=="],
+
+    "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="],
 
     "@ljharb/through": ["@ljharb/through@2.3.13", "", { "dependencies": { "call-bind": "^1.0.7" } }, "sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ=="],
 
@@ -1944,6 +1947,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "jsbi": ["jsbi@4.3.2", "", {}, "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="],
 
     "jsc-android": ["jsc-android@250231.0.0", "", {}, "sha512-rS46PvsjYmdmuz1OAWXY/1kCYG7pnf1TBqeTiOJr1iDz7s5DLxxC9n/ZMknLDxzYzNVfI7R95MH10emSSG1Wuw=="],
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "@evilmartians/lefthook": "^1.6.13",
         "@happy-dom/global-registrator": "^14.12.0",
         "@jest/globals": "^29.7.0",
+        "@js-temporal/polyfill": "^0.5.1",
         "@react-native-async-storage/async-storage": "^1.23.1",
         "@release-it/conventional-changelog": "^8.0.1",
         "@supabase/supabase-js": "^2.43.4",

--- a/src/ObservableObject.ts
+++ b/src/ObservableObject.ts
@@ -34,6 +34,7 @@ import {
     isPrimitive,
     isPromise,
     isSet,
+    isTemporal,
 } from './is';
 import { linked } from './linked';
 import type {
@@ -725,8 +726,10 @@ function setKey(node: NodeInfo, key: string, newValue?: any, level?: number) {
         const isPrim =
             isPrimitive(prevValue) ||
             prevValue instanceof Date ||
+            isTemporal(prevValue) ||
             isPrimitive(savedValue) ||
-            savedValue instanceof Date;
+            savedValue instanceof Date ||
+            isTemporal(savedValue);
 
         if (!isPrim) {
             let parent = childNode;

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,4 +1,4 @@
-import { isArray, isChildNode, isDate, isFunction, isMap, isObject, isSet } from './is';
+import { isArray, isChildNode, isDate, isFunction, isMap, isObject, isSet, isTemporal } from './is';
 import type { NodeInfo, ObservableEvent, TypeAtPath, UpdateFn } from './observableInterfaces';
 import type { Observable, ObservableParam } from './observableTypes';
 
@@ -250,7 +250,9 @@ export function extractFunction(node: NodeInfo, key: string, fnOrComputed: Funct
     node.functions.set(key, fnOrComputed);
 }
 export function equals(a: unknown, b: unknown) {
-    return a === b || (isDate(a) && isDate(b) && +a === +b);
+    return (
+        a === b || (isDate(a) && isDate(b) && +a === +b) || (isTemporal(a) && isTemporal(b) && String(a) === String(b))
+    );
 }
 export function getKeys(
     obj: Record<any, any> | Array<any> | undefined,

--- a/src/is.ts
+++ b/src/is.ts
@@ -9,7 +9,7 @@ export function isString(obj: unknown): obj is string {
     return typeof obj === 'string';
 }
 export function isObject(obj: unknown): obj is Record<any, any> {
-    return !!obj && typeof obj === 'object' && !(obj instanceof Date) && !isArray(obj);
+    return !!obj && typeof obj === 'object' && !(obj instanceof Date) && !isTemporal(obj) && !isArray(obj);
 }
 export function isPlainObject(obj: unknown): obj is Record<any, any> {
     return isObject(obj) && obj.constructor === Object;
@@ -19,10 +19,24 @@ export function isFunction(obj: unknown): obj is Function {
 }
 export function isPrimitive(arg: unknown): arg is string | number | bigint | boolean | symbol {
     const type = typeof arg;
-    return arg !== undefined && (isDate(arg) || (type !== 'object' && type !== 'function'));
+    return arg !== undefined && (isDate(arg) || isTemporal(arg) || (type !== 'object' && type !== 'function'));
 }
 export function isDate(obj: unknown): obj is Date {
     return obj instanceof Date;
+}
+// Temporal.* instances (PlainDate, PlainTime, PlainDateTime, ZonedDateTime, Instant, Duration,
+// PlainMonthDay, PlainYearMonth) have no enumerable own properties, so they must be treated as
+// opaque/primitive-like values (like Date) rather than deep-diffed. We can't rely on `instanceof
+// Temporal.X` because the global `Temporal` may not exist (native support or polyfill is optional
+// for consumers), so we duck-type via the spec-mandated `Symbol.toStringTag`, which every Temporal
+// type sets to `"Temporal.<TypeName>"`.
+export function isTemporal(obj: unknown): boolean {
+    return (
+        !!obj &&
+        (typeof obj === 'object' || typeof obj === 'function') &&
+        typeof (obj as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag] === 'string' &&
+        (obj as { [Symbol.toStringTag]: string })[Symbol.toStringTag].startsWith('Temporal.')
+    );
 }
 export function isSymbol(obj: unknown): obj is symbol {
     return typeof obj === 'symbol';

--- a/tests/computed.test.ts
+++ b/tests/computed.test.ts
@@ -302,8 +302,8 @@ describe('Computed', () => {
 
         expect(handler).toHaveBeenCalledTimes(1);
 
-        // Setting to a string that resolves to an equal PlainDate should not re-notify.
-        source$.set('2024-01-15');
+        // Setting to a different string that resolves to an equal PlainDate should not re-notify.
+        source$.set('2024-01-15T10:30:00');
 
         expect(handler).toHaveBeenCalledTimes(1);
     });

--- a/tests/computed.test.ts
+++ b/tests/computed.test.ts
@@ -1,7 +1,9 @@
+import { Temporal } from '@js-temporal/polyfill';
 import {
     Observable,
     batch,
     beginBatch,
+    computed,
     endBatch,
     getNode,
     isObservable,
@@ -254,6 +256,56 @@ describe('Computed', () => {
         expect(comp.get()).toEqual({ prev: 30, sum: 35 });
         obs.test.set(11);
         expect(comp.get()).toEqual({ prev: 35, sum: 31 });
+    });
+    test('Computed returning a Temporal.PlainDate notifies on change', () => {
+        const source$ = observable('2024-01-15');
+        const date$ = computed(() => Temporal.PlainDate.from(source$.get()));
+
+        const handler = jest.fn();
+        observe(() => {
+            handler(date$.get().toString());
+        });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenLastCalledWith('2024-01-15');
+
+        source$.set('2024-03-20');
+
+        expect(handler).toHaveBeenCalledTimes(2);
+        expect(handler).toHaveBeenLastCalledWith('2024-03-20');
+    });
+    test('Computed returning a Temporal.Instant notifies on change', () => {
+        const source$ = observable('2024-01-15T00:00:00Z');
+        const instant$ = computed(() => Temporal.Instant.from(source$.get()));
+
+        const handler = jest.fn();
+        observe(() => {
+            handler(instant$.get().toString());
+        });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenLastCalledWith('2024-01-15T00:00:00Z');
+
+        source$.set('2024-03-20T00:00:00Z');
+
+        expect(handler).toHaveBeenCalledTimes(2);
+        expect(handler).toHaveBeenLastCalledWith('2024-03-20T00:00:00Z');
+    });
+    test('Computed returning an equal Temporal.PlainDate does not notify', () => {
+        const source$ = observable('2024-01-15');
+        const date$ = computed(() => Temporal.PlainDate.from(source$.get()));
+
+        const handler = jest.fn();
+        observe(() => {
+            handler(date$.get().toString());
+        });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+
+        // Setting to a string that resolves to an equal PlainDate should not re-notify.
+        source$.set('2024-01-15');
+
+        expect(handler).toHaveBeenCalledTimes(1);
     });
 });
 describe('Accessor functions', () => {


### PR DESCRIPTION
Computed observables that wrap a `Temporal.*` value never fire their listeners on change (#650). Temporal instances have no enumerable own properties, so the change-diff treats them as empty objects and decides nothing changed.

`Temporal` values are now detected (duck-typed via `Symbol.toStringTag`, which every Temporal type sets to `"Temporal.<Type>"`, so it works whether the runtime has native Temporal or a polyfill) and treated as opaque primitive-like values compared by their string form, mirroring the existing `Date` handling. Wired into the same `isObject`/`isPrimitive`/`equals` spots that already special-case `Date`.

Added tests: a computed returning a `Temporal.PlainDate`/`Instant` notifies on change and does not notify when the value is equal. They fail without the fix (the listener fires once instead of twice) and pass with it. `@js-temporal/polyfill` is added as a dev-only dependency so the tests can run on Node, which has no native Temporal yet. tsc, eslint and prettier clean.

Closes #650
